### PR TITLE
Renamed collection and relations crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.org>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.8.0"
+version = "0.7.0"
 license = "AGPL-3.0"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"
@@ -36,8 +36,8 @@ transit_model_procmacro = { version = "0.1", path = "./transit_model_procmacro" 
 walkdir = "2.1"
 wkt = "0.5"
 zip = "0.5"
-collection = { path = "./collection" }
-relations = { path = "./relations" }
+transit_model_collection = { path = "./collection" }
+transit_model_relations = { path = "./relations" }
 
 [[test]]
 name = "kv12ntfs"

--- a/collection/Cargo.toml
+++ b/collection/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "collection"
+name = "transit_model_collection"
 description = "Manage collection of objects"
 version = "0.1.0"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]

--- a/collection/src/collection.rs
+++ b/collection/src/collection.rs
@@ -88,7 +88,7 @@ pub struct Collection<T> {
 /// # Examples
 ///
 /// ```
-/// use collection::Collection;
+/// use transit_model_collection::Collection;
 ///
 /// let collection: Collection<i32> = Collection::from(42);
 /// assert_eq!(collection.len(), 1);
@@ -114,7 +114,7 @@ impl<T> Collection<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::Collection;
+    /// use transit_model_collection::Collection;
     ///
     /// let _: Collection<i32> = Collection::new(vec![1, 1, 2, 3, 5, 8]);
     /// ```
@@ -127,7 +127,7 @@ impl<T> Collection<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::Collection;
+    /// use transit_model_collection::Collection;
     ///
     /// let c: Collection<i32> = Collection::new(vec![1, 1, 2, 3, 5, 8]);
     /// assert_eq!(c.len(), 6);
@@ -141,7 +141,7 @@ impl<T> Collection<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{Collection, Idx};
+    /// use transit_model_collection::{Collection, Idx};
     ///
     /// let c: Collection<i32> = Collection::new(vec![1, 1, 2, 3, 5, 8]);
     /// let (k, v): (Idx<i32>, &i32) = c.iter().nth(4).unwrap();
@@ -160,7 +160,7 @@ impl<T> Collection<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::Collection;
+    /// use transit_model_collection::Collection;
     ///
     /// let c: Collection<i32> = Collection::new(vec![1, 1, 2, 3, 5, 8]);
     /// let values: Vec<&i32> = c.values().collect();
@@ -175,7 +175,7 @@ impl<T> Collection<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::Collection;
+    /// use transit_model_collection::Collection;
     ///
     /// let mut c: Collection<i32> = Collection::new(vec![1, 1, 2, 3, 5, 8]);
     /// for elem in c.values_mut() {
@@ -192,7 +192,7 @@ impl<T> Collection<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{Collection, Idx};
+    /// use transit_model_collection::{Collection, Idx};
     /// use std::collections::BTreeSet;
     ///
     /// # fn get_transit_indices(c: &Collection<&'static str>) -> BTreeSet<Idx<&'static str>> {
@@ -221,7 +221,7 @@ impl<T> Collection<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{Collection, Id};
+    /// use transit_model_collection::{Collection, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -243,7 +243,7 @@ impl<T> Collection<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::Collection;
+    /// use transit_model_collection::Collection;
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -265,7 +265,7 @@ impl<T> Collection<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::Collection;
+    /// use transit_model_collection::Collection;
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -284,7 +284,7 @@ impl<T> Collection<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::Collection;
+    /// use transit_model_collection::Collection;
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj;
@@ -301,7 +301,7 @@ impl<T> Collection<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::Collection;
+    /// use transit_model_collection::Collection;
     /// use std::collections::HashSet;
     ///
     /// #[derive(PartialEq, Debug)]
@@ -322,7 +322,7 @@ impl<T> Collection<T> {
     }
 }
 
-/// The type returned by `Collection::iter`.
+/// The type returned by `transit_model_collection::iter`.
 pub type Iter<'a, T> =
     iter::Map<iter::Enumerate<slice::Iter<'a, T>>, fn((usize, &T)) -> (Idx<T>, &T)>;
 
@@ -387,7 +387,7 @@ pub struct CollectionWithId<T> {
 /// # Examples
 ///
 /// ```
-/// use collection::{CollectionWithId, Id};
+/// use transit_model_collection::{CollectionWithId, Id};
 ///
 /// #[derive(PartialEq, Debug)]
 /// struct Obj(&'static str);
@@ -417,7 +417,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -453,7 +453,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     /// use std::collections::HashMap;
     ///
     /// #[derive(PartialEq, Debug)]
@@ -479,7 +479,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -497,7 +497,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// ```
     ///
     /// ```should_panic
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -524,7 +524,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -549,7 +549,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -586,7 +586,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     /// use std::collections::HashSet;
     ///
     /// #[derive(PartialEq, Debug)]
@@ -618,7 +618,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -649,7 +649,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -678,7 +678,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// identifier already in the collection, and the second parameter is the
     /// element to be inserted.
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(Debug, Default)]
     /// struct ObjectId {
@@ -742,7 +742,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -766,7 +766,7 @@ impl<T: Id<T> + WithId> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// # use collection::{CollectionWithId, Id, WithId};
+    /// # use transit_model_collection::{CollectionWithId, Id, WithId};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(String);
@@ -800,7 +800,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id, WithId};
+    /// use transit_model_collection::{CollectionWithId, Id, WithId};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(String, String);
@@ -844,7 +844,7 @@ impl<T: Id<T>> iter::Extend<T> for CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -878,7 +878,7 @@ impl<T> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -903,7 +903,7 @@ impl<T> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -926,7 +926,7 @@ impl<T> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);
@@ -950,7 +950,7 @@ impl<T> CollectionWithId<T> {
     /// # Examples
     ///
     /// ```
-    /// use collection::{CollectionWithId, Id};
+    /// use transit_model_collection::{CollectionWithId, Id};
     ///
     /// #[derive(PartialEq, Debug)]
     /// struct Obj(&'static str);

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -14,10 +14,10 @@
 // along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 
-use transit_model::collection::{CollectionWithId, Id, Idx};
 use transit_model::model::GetCorresponding;
-use transit_model::relations::IdxSet;
 use transit_model::{Model, Result};
+use transit_model_collection::{CollectionWithId, Id, Idx};
+use transit_model_relations::IdxSet;
 
 fn get<T, U>(idx: Idx<T>, collection: &CollectionWithId<U>, objects: &Model) -> Vec<String>
 where

--- a/model-builder/Cargo.toml
+++ b/model-builder/Cargo.toml
@@ -10,3 +10,5 @@ description = "A crate to easily build a transit_model::Model"
 # Swap the next two lines when publishing
 # transit_model = "0.6"
 transit_model = { path = "../" }
+# transit_model_collection = "0.1"
+transit_model_collection = { path = "../collection" }

--- a/model-builder/src/builder.rs
+++ b/model-builder/src/builder.rs
@@ -32,9 +32,9 @@
 //! # }
 //! ```
 
-use crate::collection::Idx;
 use crate::model::{Collections, Model};
 use crate::objects::{Calendar, Route, StopPoint, StopTime, Time, VehicleJourney};
+use transit_model_collection::Idx;
 
 /// Builder used to easily create a `Model`
 #[derive(Default)]

--- a/model-builder/src/lib.rs
+++ b/model-builder/src/lib.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 
-use transit_model::{collection, model, objects};
+use transit_model::{model, objects};
 
 mod builder;
 

--- a/relations/Cargo.toml
+++ b/relations/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "relations"
+name = "transit_model_relations"
 description = " Modeling the relations between objects"
 version = "0.1.0"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
@@ -11,5 +11,5 @@ keywords = ["relations", "collection"]
 [dependencies]
 derivative = "1.0.3"
 failure = "0.1.5"
-collection = { path = "../collection" }
+transit_model_collection = { path = "../collection" }
 transit_model_procmacro = { path = "../transit_model_procmacro" }

--- a/relations/src/relations.rs
+++ b/relations/src/relations.rs
@@ -34,8 +34,8 @@
 //!
 //! ```no_run
 //! # use transit_model_procmacro::*;
-//! # use crate::relations::*;
-//! # use collection::Idx;
+//! # use transit_model_relations::*;
+//! # use transit_model_collection::Idx;
 //! # struct Bike;
 //! # struct Brand;
 //! # struct Owner;
@@ -109,8 +109,8 @@
 //!
 //! ```
 //! # use transit_model_procmacro::*;
-//! # use crate::relations::*;
-//! # use collection::Idx;
+//! # use transit_model_relations::*;
+//! # use transit_model_collection::Idx;
 //! # struct Bike;
 //! # struct Brand;
 //! # struct Owner;
@@ -165,7 +165,7 @@ pub type Error = failure::Error;
 /// The corresponding result type used by the crate.
 pub type Result<T> = std::result::Result<T, Error>;
 
-use collection::{CollectionWithId, Id, Idx};
+use transit_model_collection::{CollectionWithId, Id, Idx};
 
 use derivative::Derivative;
 use failure::{format_err, ResultExt};

--- a/src/add_prefix.rs
+++ b/src/add_prefix.rs
@@ -16,10 +16,8 @@
 
 //! A trait for every structure that needs to be updated with a prefix
 
-use crate::{
-    collection::{Collection, CollectionWithId, Id},
-    model::Collections,
-};
+use crate::model::Collections;
+use transit_model_collection::{Collection, CollectionWithId, Id};
 
 pub trait AddPrefix {
     fn add_prefix(&mut self, prefix: &str);

--- a/src/apply_rules.rs
+++ b/src/apply_rules.rs
@@ -16,7 +16,6 @@
 
 //! See function apply_rules
 
-use crate::collection::{CollectionWithId, Id, Idx};
 use crate::model::Collections;
 use crate::utils::{Report, ReportType};
 use crate::Result;
@@ -24,7 +23,6 @@ use crate::{
     objects::{
         Codes, Coord, Geometry, Line, Network, ObjectType as ModelObjectType, VehicleJourney,
     },
-    relations::IdxSet,
     Model,
 };
 use csv;
@@ -39,6 +37,8 @@ use std::fs;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use transit_model_collection::{CollectionWithId, Id, Idx};
+use transit_model_relations::IdxSet;
 use wkt::{self, conversion::try_into_geometry};
 
 #[derive(Deserialize, Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Copy, Hash)]

--- a/src/common_format.rs
+++ b/src/common_format.rs
@@ -14,7 +14,6 @@
 // along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 
-use crate::collection::*;
 use crate::model::Collections;
 use crate::objects::{self, Date, ExceptionType};
 use crate::read_utils::FileHandler;
@@ -30,6 +29,7 @@ use log::info;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::path;
+use transit_model_collection::*;
 
 #[derive(Serialize, Deserialize, Debug, Derivative, PartialEq, Eq, Hash, Clone, Copy)]
 #[derivative(Default)]

--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -20,7 +20,6 @@ mod read;
 mod write;
 
 use crate::{
-    collection::{CollectionWithId, Idx},
     common_format::{manage_calendars, write_calendar_dates, Availability},
     gtfs::read::EquipmentList,
     model::{Collections, Model},
@@ -36,6 +35,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fs::File;
 use std::path::Path;
+use transit_model_collection::{CollectionWithId, Idx};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct Agency {

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -18,7 +18,6 @@ use super::{
     Agency, DirectionType, Route, RouteType, Shape, Stop, StopLocationType, StopTime, Transfer,
     TransferType, Trip,
 };
-use crate::collection::{Collection, CollectionWithId, Id};
 use crate::common_format::Availability;
 use crate::model::Collections;
 use crate::objects::{
@@ -36,6 +35,7 @@ use log::{info, warn};
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::result::Result as StdResult;
+use transit_model_collection::{Collection, CollectionWithId, Id};
 
 fn default_agency_id() -> String {
     "default_agency_id".to_string()
@@ -1055,7 +1055,6 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        collection::{Collection, CollectionWithId, Id},
         common_format,
         gtfs::read::EquipmentList,
         model::Collections,
@@ -1067,6 +1066,7 @@ mod tests {
     use chrono;
     use geo_types::line_string;
     use std::collections::BTreeSet;
+    use transit_model_collection::{Collection, CollectionWithId, Id};
 
     fn extract<'a, T, S: ::std::cmp::Ord>(f: fn(&'a T) -> S, c: &'a Collection<T>) -> Vec<S> {
         let mut extracted_props: Vec<S> = c.values().map(|l| f(l)).collect();

--- a/src/gtfs/write.rs
+++ b/src/gtfs/write.rs
@@ -18,13 +18,11 @@ use super::{
     Agency, DirectionType, Route, RouteType, Shape, Stop, StopLocationType, StopTime, Transfer,
     Trip,
 };
-use crate::collection::{Collection, CollectionWithId, Id, Idx};
 use crate::common_format::Availability;
 use crate::model::{GetCorresponding, Model};
 use crate::objects;
 use crate::objects::Transfer as NtfsTransfer;
 use crate::objects::*;
-use crate::relations::IdxSet;
 use crate::Result;
 use csv;
 use failure::ResultExt;
@@ -33,6 +31,8 @@ use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path;
+use transit_model_collection::{Collection, CollectionWithId, Id, Idx};
+use transit_model_relations::IdxSet;
 
 pub fn write_transfers(path: &path::Path, transfers: &Collection<NtfsTransfer>) -> Result<()> {
     if transfers.is_empty() {
@@ -480,7 +480,6 @@ pub fn write_shapes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::collection::CollectionWithId;
     use crate::common_format::write_calendar_dates;
     use crate::gtfs::{Route, RouteType, StopLocationType, Transfer, TransferType};
     use crate::objects::Transfer as NtfsTransfer;
@@ -491,6 +490,7 @@ mod tests {
     use std::fs::File;
     use std::io::Read;
     use tempfile::tempdir;
+    use transit_model_collection::CollectionWithId;
 
     #[test]
     fn write_agency() {

--- a/src/kv1/mod.rs
+++ b/src/kv1/mod.rs
@@ -19,12 +19,12 @@
 mod read;
 
 use crate::{
-    collection::CollectionWithId,
     model::{Collections, Model},
     read_utils, AddPrefix, Result,
 };
 use std::fs::File;
 use std::path::Path;
+use transit_model_collection::CollectionWithId;
 
 fn read<H>(
     file_handler: &mut H,

--- a/src/kv1/read.rs
+++ b/src/kv1/read.rs
@@ -15,7 +15,6 @@
 // <http://www.gnu.org/licenses/>.
 
 use crate::{
-    collection::{CollectionWithId, Id},
     common_format::{Availability, CalendarDate},
     model::Collections,
     objects::*,
@@ -33,6 +32,7 @@ use proj::Proj;
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::result::Result as StdResult;
+use transit_model_collection::{CollectionWithId, Id};
 
 /// Deserialize kv1 string date (Y-m-d) to NaiveDate
 fn de_from_date_string<'de, D>(deserializer: D) -> StdResult<Date, D::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,3 @@ pub type Error = failure::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub use crate::model::Model;
-
-pub use collection;
-pub use relations;

--- a/src/merge_stop_areas.rs
+++ b/src/merge_stop_areas.rs
@@ -18,7 +18,6 @@
 
 use serde_json;
 
-use crate::collection::{Collection, CollectionWithId};
 use crate::model::Collections;
 use crate::objects::{CommentLinksT, KeysValues};
 use crate::objects::{RestrictionType, StopArea};
@@ -32,6 +31,7 @@ use std::fs;
 use std::path;
 use std::path::PathBuf;
 use std::result::Result as StdResult;
+use transit_model_collection::{Collection, CollectionWithId};
 
 #[derive(Deserialize, Debug)]
 struct StopAreaMergeRule {

--- a/src/model.rs
+++ b/src/model.rs
@@ -16,12 +16,7 @@
 
 //! Definition of the navitia transit model.
 
-use crate::{
-    collection::{Collection, CollectionWithId, Id, Idx},
-    objects::*,
-    relations::{IdxSet, ManyToMany, OneToMany, Relation},
-    Error, Result,
-};
+use crate::{objects::*, Error, Result};
 use chrono::NaiveDate;
 use derivative::Derivative;
 use failure::format_err;
@@ -30,7 +25,9 @@ use std::cmp;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::ops;
 use std::result::Result as StdResult;
+use transit_model_collection::{Collection, CollectionWithId, Id, Idx};
 use transit_model_procmacro::*;
+use transit_model_relations::{IdxSet, ManyToMany, OneToMany, Relation};
 
 /// The set of collections representing the model.
 #[derive(Derivative, Serialize, Deserialize, Debug)]
@@ -516,7 +513,7 @@ impl Model {
     ///
     /// ```
     /// # use transit_model::model::*;
-    /// # use transit_model::collection::Collection;
+    /// # use transit_model_collection::Collection;
     /// # use transit_model::objects::Transfer;
     /// let mut collections = Collections::default();
     /// // This transfer is invalid as there is no stop points in collections

--- a/src/ntfs/mod.rs
+++ b/src/ntfs/mod.rs
@@ -263,8 +263,6 @@ mod tests {
 
     use super::Collections;
     use super::{read, write};
-    use crate::collection::*;
-    use crate::collection::{Collection, CollectionWithId};
     use crate::common_format;
     use crate::objects::*;
     use crate::read_utils::PathFileHandler;
@@ -275,6 +273,8 @@ mod tests {
     use serde;
     use std::collections::{BTreeMap, BTreeSet, HashMap};
     use std::fmt::Debug;
+    use transit_model_collection::*;
+    use transit_model_collection::{Collection, CollectionWithId};
 
     fn test_serialize_deserialize_collection_with_id<T>(objects: Vec<T>)
     where

--- a/src/ntfs/read.rs
+++ b/src/ntfs/read.rs
@@ -18,7 +18,6 @@ use csv;
 use std::path;
 
 use super::{Code, CommentLink, ObjectProperty, Stop, StopLocationType, StopTime};
-use crate::collection::*;
 use crate::model::Collections;
 use crate::ntfs::has_fares_v2;
 use crate::objects::*;
@@ -28,6 +27,7 @@ use failure::{bail, ensure, format_err, ResultExt};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use transit_model_collection::*;
 
 impl From<Stop> for StopArea {
     fn from(stop: Stop) -> StopArea {

--- a/src/ntfs/write.rs
+++ b/src/ntfs/write.rs
@@ -15,7 +15,6 @@
 // <http://www.gnu.org/licenses/>.
 
 use super::{Code, CommentLink, ObjectProperty, Result, Stop, StopLocationType, StopTime};
-use crate::collection::{Collection, CollectionWithId, Id, Idx};
 use crate::model::Collections;
 use crate::ntfs::{has_fares_v1, has_fares_v2};
 use crate::objects::*;
@@ -29,6 +28,7 @@ use serde;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::TryFrom;
 use std::path;
+use transit_model_collection::{Collection, CollectionWithId, Id, Idx};
 
 impl TryFrom<(&Ticket, &TicketPrice)> for PriceV1 {
     type Error = failure::Error;

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -18,12 +18,7 @@
 
 #![allow(missing_docs)]
 
-use crate::{
-    collection::{Id, Idx, WithId},
-    common_format::Availability,
-    utils::*,
-    AddPrefix,
-};
+use crate::{common_format::Availability, utils::*, AddPrefix};
 use chrono;
 use chrono::NaiveDate;
 use derivative::Derivative;
@@ -35,6 +30,7 @@ use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
 use std::ops::{Add, Div, Sub};
 use std::str::FromStr;
+use transit_model_collection::{Id, Idx, WithId};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]

--- a/src/read_utils.rs
+++ b/src/read_utils.rs
@@ -15,7 +15,6 @@
 // <http://www.gnu.org/licenses/>.
 
 use crate::{
-    collection::{CollectionWithId, Id},
     objects::{self, Contributor},
     Result,
 };
@@ -28,6 +27,7 @@ use std::fs::File;
 use std::path;
 use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
+use transit_model_collection::{CollectionWithId, Id};
 
 #[derive(Deserialize, Debug)]
 struct ConfigDataset {

--- a/src/transfers.rs
+++ b/src/transfers.rs
@@ -16,7 +16,6 @@
 
 //! See function generates_transfers
 
-use crate::collection::{Collection, CollectionWithId, Idx};
 use crate::model::Model;
 use crate::objects::{Contributor, StopPoint, Transfer};
 use crate::utils::{Report, ReportType};
@@ -31,6 +30,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
+use transit_model_collection::{Collection, CollectionWithId, Idx};
 
 #[derive(Deserialize, Debug)]
 struct Rule {

--- a/src/transxchange/naptan.rs
+++ b/src/transxchange/naptan.rs
@@ -18,7 +18,6 @@
 //! https://en.wikipedia.org/wiki/NaPTAN
 
 use crate::{
-    collection::CollectionWithId,
     model::Collections,
     objects::{Coord, KeysValues, StopArea, StopPoint},
     read_utils::{self, FileHandler},
@@ -31,6 +30,7 @@ use log::{info, warn};
 use proj::Proj;
 use serde::Deserialize;
 use std::{collections::HashMap, fs::File, io::Read, path::Path};
+use transit_model_collection::CollectionWithId;
 
 #[derive(Debug, Deserialize)]
 pub struct NaPTANStop {

--- a/src/transxchange/read.rs
+++ b/src/transxchange/read.rs
@@ -15,7 +15,6 @@
 // <http://www.gnu.org/licenses/>.
 
 use crate::{
-    collection::CollectionWithId,
     minidom_utils::TryOnlyChild,
     model::{Collections, Model},
     objects::*,
@@ -37,6 +36,7 @@ use std::{
     io::Read,
     path::Path,
 };
+use transit_model_collection::CollectionWithId;
 use walkdir::WalkDir;
 use zip::ZipArchive;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,10 +14,7 @@
 // along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 
-use crate::{
-    collection::{Collection, CollectionWithId, Id},
-    objects::Date,
-};
+use crate::objects::Date;
 use chrono::NaiveDate;
 use csv;
 use failure::ResultExt;
@@ -28,6 +25,7 @@ use serde::Serialize;
 use std::fs;
 use std::io::{Read, Write};
 use std::path;
+use transit_model_collection::{Collection, CollectionWithId, Id};
 use walkdir::WalkDir;
 use wkt::{self, conversion::try_into_geometry, ToWkt};
 use zip;

--- a/tests/merge_ntfs.rs
+++ b/tests/merge_ntfs.rs
@@ -18,14 +18,14 @@ use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
 use std::path::Path;
 use transit_model;
-use transit_model::collection::CollectionWithId;
-use transit_model::collection::Idx;
 use transit_model::model::Collections;
 use transit_model::model::Model;
 use transit_model::objects::{Comment, StopPoint, VehicleJourney};
 use transit_model::test_utils::*;
 use transit_model::transfers;
 use transit_model::transfers::TransfersMode;
+use transit_model_collection::CollectionWithId;
+use transit_model_collection::Idx;
 
 #[test]
 #[should_panic(expected = "TGC already found")] // first collision is on contributor id

--- a/tests/read_ntfs.rs
+++ b/tests/read_ntfs.rs
@@ -16,11 +16,11 @@
 
 use std::collections::HashMap;
 use transit_model;
-use transit_model::collection::{CollectionWithId, Id, Idx};
 use transit_model::model::{GetCorresponding, Model};
 use transit_model::objects::*;
-use transit_model::relations::IdxSet;
 use transit_model::test_utils::*;
+use transit_model_collection::{CollectionWithId, Id, Idx};
+use transit_model_relations::IdxSet;
 
 fn get<T, U>(idx: Idx<T>, collection: &CollectionWithId<U>, objects: &Model) -> Vec<String>
 where

--- a/transit_model_procmacro/src/lib.rs
+++ b/transit_model_procmacro/src/lib.rs
@@ -15,7 +15,7 @@
 // <http://www.gnu.org/licenses/>.
 
 //! Custom derive for GetCorresponding.  See
-//! `transit_model::relations` for the documentation.
+//! `transit_model_relations` for the documentation.
 
 #![recursion_limit = "128"]
 


### PR DESCRIPTION
`collection` and `relations` crates must be published before publishing `transit_model` but the crate `collection` already exist in crates.io so I renamed `collection` to `transit_model_collection` and `relations` to `transit_model_relations`