### PR TITLE
[feature] update to 'minidom:0.13.0'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,13 +44,11 @@ iso4217 = "0.3"
 lazy_static = "1"
 log = "0.4"
 md5 = "0.7"
-minidom = "0.12"
+minidom = "0.13"
 minidom_ext = "1"
-minidom_writer = "1"
 num-traits = "0.2"
 pretty_assertions = "0.6"
 proj = { version = "0.19", optional = true }
-quick-xml = "0.18"
 relational_types = "1"
 rust_decimal = "1"
 serde = { version = "1", features = ["derive"] }
@@ -72,3 +70,6 @@ approx = "0.3"
 rust_decimal_macros = "1"
 testing_logger = "0.1"
 transit_model_builder = { path = "./model-builder"}
+
+[patch.crates-io]
+minidom_ext = { git = "https://github.com/CanalTP/minidom_ext", branch = "minidom-0.13" }

--- a/src/netex_france/calendars.rs
+++ b/src/netex_france/calendars.rs
@@ -13,7 +13,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>
 
 use crate::{
-    netex_france::exporter::{Exporter, ObjectType},
+    netex_france::{
+        exporter::{Exporter, ObjectType},
+        NETEX_NS,
+    },
     objects::{Calendar, Date},
     Model, Result,
 };
@@ -60,7 +63,7 @@ impl<'a> CalendarExporter<'a> {
 // Internal methods
 impl<'a> CalendarExporter<'a> {
     fn export_day_type(&self, calendar: &'a Calendar) -> Element {
-        Element::builder(ObjectType::DayType.to_string())
+        Element::builder(ObjectType::DayType.to_string(), NETEX_NS)
             .attr(
                 "id",
                 Exporter::generate_id(&calendar.id, ObjectType::DayType),
@@ -70,7 +73,7 @@ impl<'a> CalendarExporter<'a> {
     }
 
     fn export_day_type_assignement(&self, calendar: &'a Calendar) -> Element {
-        Element::builder(ObjectType::DayTypeAssignment.to_string())
+        Element::builder(ObjectType::DayTypeAssignment.to_string(), NETEX_NS)
             .attr(
                 "id",
                 Exporter::generate_id(&calendar.id, ObjectType::DayTypeAssignment),
@@ -86,15 +89,16 @@ impl<'a> CalendarExporter<'a> {
         if let Some(from_date) = calendar.dates.iter().next() {
             let from_date = Self::generate_from_date(*from_date);
             let valid_day_bits = Self::generate_valid_day_bits(&calendar.dates);
-            let uic_operating_period = Element::builder(ObjectType::UicOperatingPeriod.to_string())
-                .attr(
-                    "id",
-                    Exporter::generate_id(&calendar.id, ObjectType::UicOperatingPeriod),
-                )
-                .attr("version", "any")
-                .append(from_date)
-                .append(valid_day_bits)
-                .build();
+            let uic_operating_period =
+                Element::builder(ObjectType::UicOperatingPeriod.to_string(), NETEX_NS)
+                    .attr(
+                        "id",
+                        Exporter::generate_id(&calendar.id, ObjectType::UicOperatingPeriod),
+                    )
+                    .attr("version", "any")
+                    .append(from_date)
+                    .append(valid_day_bits)
+                    .build();
             Ok(uic_operating_period)
         } else {
             bail!(
@@ -106,7 +110,7 @@ impl<'a> CalendarExporter<'a> {
 
     fn generate_from_date(date: Date) -> Element {
         let date_string = DateTime::<Utc>::from_utc(date.and_hms(0, 0, 0), Utc).to_rfc3339();
-        Element::builder("FromDate")
+        Element::builder("FromDate", NETEX_NS)
             .append(Node::Text(date_string))
             .build()
     }
@@ -128,13 +132,13 @@ impl<'a> CalendarExporter<'a> {
                     valid_day_bits
                 })
         };
-        Element::builder("ValidDayBits")
+        Element::builder("ValidDayBits", NETEX_NS)
             .append(Node::Text(valid_day_bits_string))
             .build()
     }
 
     fn generate_operating_period_ref(&self, id: &'a str) -> Element {
-        Element::builder("OperatingPeriodRef")
+        Element::builder("OperatingPeriodRef", NETEX_NS)
             .attr(
                 "ref",
                 Exporter::generate_id(id, ObjectType::UicOperatingPeriod),
@@ -143,7 +147,7 @@ impl<'a> CalendarExporter<'a> {
     }
 
     fn generate_day_type_ref(&self, id: &'a str) -> Element {
-        Element::builder("DayTypeRef")
+        Element::builder("DayTypeRef", NETEX_NS)
             .attr("ref", Exporter::generate_id(id, ObjectType::DayType))
             .build()
     }

--- a/src/netex_france/companies.rs
+++ b/src/netex_france/companies.rs
@@ -13,7 +13,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>
 
 use crate::{
-    netex_france::exporter::{Exporter, ObjectType},
+    netex_france::{
+        exporter::{Exporter, ObjectType},
+        NETEX_NS,
+    },
     objects::Company,
     Model,
 };
@@ -40,7 +43,7 @@ impl<'a> CompanyExporter<'a> {
 // Internal methods
 impl<'a> CompanyExporter<'a> {
     fn export_company(&self, company: &'a Company) -> Element {
-        let element_builder = Element::builder(ObjectType::Operator.to_string())
+        let element_builder = Element::builder(ObjectType::Operator.to_string(), NETEX_NS)
             .attr(
                 "id",
                 Exporter::generate_id(&company.id, ObjectType::Operator),
@@ -53,13 +56,13 @@ impl<'a> CompanyExporter<'a> {
     }
 
     fn generate_name(&self, company: &'a Company) -> Element {
-        Element::builder("Name")
+        Element::builder("Name", NETEX_NS)
             .append(Node::Text(company.name.to_owned()))
             .build()
     }
 
     fn generate_contact_details(&self, company: &'a Company) -> Element {
-        let element_builder = Element::builder("ContactDetails");
+        let element_builder = Element::builder("ContactDetails", NETEX_NS);
         let element_builder = if let Some(email_element) = self.generate_email(company) {
             element_builder.append(email_element)
         } else {
@@ -80,7 +83,7 @@ impl<'a> CompanyExporter<'a> {
 
     fn generate_email(&self, company: &'a Company) -> Option<Element> {
         company.mail.as_ref().map(|email| {
-            Element::builder("Email")
+            Element::builder("Email", NETEX_NS)
                 .append(Node::Text(email.to_owned()))
                 .build()
         })
@@ -88,7 +91,7 @@ impl<'a> CompanyExporter<'a> {
 
     fn generate_phone(&self, company: &'a Company) -> Option<Element> {
         company.phone.as_ref().map(|phone| {
-            Element::builder("Phone")
+            Element::builder("Phone", NETEX_NS)
                 .append(Node::Text(phone.to_owned()))
                 .build()
         })
@@ -96,14 +99,14 @@ impl<'a> CompanyExporter<'a> {
 
     fn generate_url(&self, company: &'a Company) -> Option<Element> {
         company.url.as_ref().map(|url| {
-            Element::builder("Url")
+            Element::builder("Url", NETEX_NS)
                 .append(Node::Text(url.to_owned()))
                 .build()
         })
     }
 
     fn generate_organization_type() -> Element {
-        Element::builder("OrganisationType")
+        Element::builder("OrganisationType", NETEX_NS)
             .append(Node::Text(String::from("other")))
             .build()
     }

--- a/src/netex_france/lines.rs
+++ b/src/netex_france/lines.rs
@@ -15,7 +15,7 @@
 use crate::{
     netex_france::{
         exporter::{Exporter, ObjectType},
-        NetexMode,
+        NetexMode, NETEX_NS,
     },
     objects::Line,
     Model, Result,
@@ -74,7 +74,7 @@ impl<'a> LineExporter<'a> {
 // Internal methods
 impl<'a> LineExporter<'a> {
     fn export_line(&self, line: &'a Line) -> Result<Element> {
-        let element_builder = Element::builder(ObjectType::Line.to_string())
+        let element_builder = Element::builder(ObjectType::Line.to_string(), NETEX_NS)
             .attr("id", Exporter::generate_id(&line.id, ObjectType::Line))
             .attr("version", "any");
         // Errors should never happen; a line always have one trip with associated mode
@@ -96,21 +96,21 @@ impl<'a> LineExporter<'a> {
     }
 
     fn generate_name(&self, line: &'a Line) -> Element {
-        Element::builder("Name")
+        Element::builder("Name", NETEX_NS)
             .append(Node::Text(line.name.to_owned()))
             .build()
     }
 
     fn generate_transport_mode(&self, netex_mode: NetexMode) -> Element {
         let transport_mode_text = Node::Text(netex_mode.to_string());
-        Element::builder("TransportMode")
+        Element::builder("TransportMode", NETEX_NS)
             .append(transport_mode_text)
             .build()
     }
 
     fn generate_public_code(&self, line: &'a Line) -> Option<Element> {
         line.code.as_ref().map(|code| {
-            Element::builder("PublicCode")
+            Element::builder("PublicCode", NETEX_NS)
                 .append(Node::Text(code.to_owned()))
                 .build()
         })

--- a/src/netex_france/mod.rs
+++ b/src/netex_france/mod.rs
@@ -35,3 +35,11 @@ mod stops;
 use stops::StopExporter;
 mod transfers;
 use transfers::TransferExporter;
+
+const CORE_NS: &str = "http://www.govtalk.gov.uk/core";
+const GML_NS: &str = "http://www.opengis.net/gml/3.2";
+const IFOPT_NS: &str = "http://www.ifopt.org.uk/ifopt";
+const NETEX_NS: &str = "http://www.netex.org.uk/netex";
+const SIRI_NS: &str = "http://www.siri.org.uk/siri";
+const XLINK_NS: &str = "http://www.w3.org/1999/xlink";
+const XSI_NS: &str = "http://www.w3.org/2001/XMLSchema-instance";

--- a/src/netex_france/networks.rs
+++ b/src/netex_france/networks.rs
@@ -13,7 +13,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>
 
 use crate::{
-    netex_france::exporter::{Exporter, ObjectType},
+    netex_france::{
+        exporter::{Exporter, ObjectType},
+        NETEX_NS,
+    },
     objects::{Line, Network},
     Model,
 };
@@ -40,7 +43,7 @@ impl<'a> NetworkExporter<'a> {
 // Internal methods
 impl<'a> NetworkExporter<'a> {
     fn export_network(&self, network: &'a Network) -> Element {
-        let element_builder = Element::builder(ObjectType::Network.to_string())
+        let element_builder = Element::builder(ObjectType::Network.to_string(), NETEX_NS)
             .attr(
                 "id",
                 Exporter::generate_id(&network.id, ObjectType::Network),
@@ -58,13 +61,15 @@ impl<'a> NetworkExporter<'a> {
     }
 
     fn generate_name(&self, network: &'a Network) -> Element {
-        Element::builder("Name")
+        Element::builder("Name", NETEX_NS)
             .append(Node::Text(network.name.to_owned()))
             .build()
     }
 
     fn generate_line_ref(&self, line: &'a Line) -> Element {
         let line_id = Exporter::generate_id(&line.id, ObjectType::Line);
-        Element::builder("LineRef").attr("ref", line_id).build()
+        Element::builder("LineRef", NETEX_NS)
+            .attr("ref", line_id)
+            .build()
     }
 }

--- a/src/netex_france/offer.rs
+++ b/src/netex_france/offer.rs
@@ -16,7 +16,7 @@ use crate::{
     netex_france::{
         self,
         exporter::{Exporter, ObjectType},
-        LineExporter, LineModes, NetexMode, StopExporter,
+        LineExporter, LineModes, NetexMode, StopExporter, GML_NS, NETEX_NS,
     },
     objects::{Coord, Line, Route, StopPoint, StopTime, Time, VehicleJourney},
     Model, Result,
@@ -156,7 +156,7 @@ impl<'a> OfferExporter<'a> {
 
     fn export_route(&self, route_idx: Idx<Route>) -> Result<Element> {
         let route = &self.model.routes[route_idx];
-        let element_builder = Element::builder(ObjectType::Route.to_string())
+        let element_builder = Element::builder(ObjectType::Route.to_string(), NETEX_NS)
             .attr("id", Exporter::generate_id(&route.id, ObjectType::Route))
             .attr("version", "any");
         let element_builder = element_builder.append(Self::generate_route_name(&route.name));
@@ -213,10 +213,10 @@ impl<'a> OfferExporter<'a> {
 
     fn export_journey_pattern(&self, journey_pattern_idx: Idx<JourneyPattern>) -> Element {
         let journey_pattern = &self.model.vehicle_journeys[journey_pattern_idx];
-        let points_in_sequence = Element::builder("pointsInSequence")
+        let points_in_sequence = Element::builder("pointsInSequence", NETEX_NS)
             .append_all(self.export_stop_points_in_journey_pattern(journey_pattern_idx))
             .build();
-        Element::builder(ObjectType::ServiceJourneyPattern.to_string())
+        Element::builder(ObjectType::ServiceJourneyPattern.to_string(), NETEX_NS)
             .attr(
                 "id",
                 Exporter::generate_id(&journey_pattern.id, ObjectType::ServiceJourneyPattern),
@@ -247,7 +247,7 @@ impl<'a> OfferExporter<'a> {
         vehicle_journey_id: &'a str,
         stop_time: &'a StopTime,
     ) -> Element {
-        Element::builder(ObjectType::StopPointInJourneyPattern.to_string())
+        Element::builder(ObjectType::StopPointInJourneyPattern.to_string(), NETEX_NS)
             .attr(
                 "id",
                 Self::generate_stop_sequence_id(
@@ -284,16 +284,17 @@ impl<'a> OfferExporter<'a> {
         vehicle_journey_id: &'a str,
         stop_time: &'a StopTime,
     ) -> Result<Element> {
-        let element_builder = Element::builder(ObjectType::ScheduledStopPoint.to_string())
-            .attr(
-                "id",
-                Self::generate_stop_sequence_id(
-                    &vehicle_journey_id,
-                    stop_time.sequence,
-                    ObjectType::ScheduledStopPoint,
-                ),
-            )
-            .attr("version", "any");
+        let element_builder =
+            Element::builder(ObjectType::ScheduledStopPoint.to_string(), NETEX_NS)
+                .attr(
+                    "id",
+                    Self::generate_stop_sequence_id(
+                        &vehicle_journey_id,
+                        stop_time.sequence,
+                        ObjectType::ScheduledStopPoint,
+                    ),
+                )
+                .attr("version", "any");
         let element_builder = if let Some(location_element) =
             self.generate_location(&self.model.stop_points[stop_time.stop_point_idx].coord)?
         {
@@ -321,17 +322,18 @@ impl<'a> OfferExporter<'a> {
         vehicle_journey: &'a VehicleJourney,
         stop_time: &'a StopTime,
     ) -> Element {
-        let element_builder = Element::builder(ObjectType::PassengerStopAssignment.to_string())
-            .attr(
-                "id",
-                Self::generate_stop_sequence_id(
-                    &vehicle_journey.id,
-                    stop_time.sequence,
-                    ObjectType::PassengerStopAssignment,
-                ),
-            )
-            .attr("version", "any")
-            .attr("order", stop_time.sequence + 1);
+        let element_builder =
+            Element::builder(ObjectType::PassengerStopAssignment.to_string(), NETEX_NS)
+                .attr(
+                    "id",
+                    Self::generate_stop_sequence_id(
+                        &vehicle_journey.id,
+                        stop_time.sequence,
+                        ObjectType::PassengerStopAssignment,
+                    ),
+                )
+                .attr("version", "any")
+                .attr("order", stop_time.sequence + 1);
         let element_builder = element_builder.append(Self::generate_scheduled_stop_point_ref(
             &vehicle_journey.id,
             stop_time.sequence,
@@ -378,7 +380,7 @@ impl<'a> OfferExporter<'a> {
             .get(line_id.as_str())
             .and_then(|line_netex_modes| NetexMode::calculate_highest_mode(line_netex_modes));
 
-        let element_builder = Element::builder(ObjectType::ServiceJourney.to_string())
+        let element_builder = Element::builder(ObjectType::ServiceJourney.to_string(), NETEX_NS)
             .attr(
                 "id",
                 Exporter::generate_id(&vehicle_journey.id, ObjectType::ServiceJourney),
@@ -398,7 +400,7 @@ impl<'a> OfferExporter<'a> {
             element_builder.append(Self::generate_journey_pattern_ref(journey_pattern_id));
         let element_builder =
             element_builder.append(Self::generate_operator_ref(&vehicle_journey.company_id));
-        let passing_times = Element::builder("passingTimes")
+        let passing_times = Element::builder("passingTimes", NETEX_NS)
             .append_all(Self::export_timetabled_passing_times(
                 &vehicle_journey.stop_times,
             ))
@@ -427,7 +429,7 @@ impl<'a> OfferExporter<'a> {
             stop_time.departure_time.minutes(),
             stop_time.departure_time.seconds(),
         );
-        Element::builder(ObjectType::TimetabledPassingTime.to_string())
+        Element::builder(ObjectType::TimetabledPassingTime.to_string(), NETEX_NS)
             .append(Self::generate_arrival_time(arrival_time))
             .append(Self::generate_arrival_day_offset(arrival_day_offset))
             .append(Self::generate_departure_time(departure_time))
@@ -436,13 +438,13 @@ impl<'a> OfferExporter<'a> {
     }
 
     fn generate_route_name(route_name: &'a str) -> Element {
-        Element::builder("Name")
+        Element::builder("Name", NETEX_NS)
             .append(Node::Text(route_name.to_owned()))
             .build()
     }
 
     fn generate_distance() -> Element {
-        Element::builder("Distance")
+        Element::builder("Distance", NETEX_NS)
             .append(Node::Text(String::from("0")))
             .build()
     }
@@ -453,7 +455,7 @@ impl<'a> OfferExporter<'a> {
         })?;
         let points_on_route =
             (1..=route_points.len()).map(|order| self.generate_point_on_route(route_id, order));
-        let points_in_sequence = Element::builder("pointsInSequence")
+        let points_in_sequence = Element::builder("pointsInSequence", NETEX_NS)
             .append_all(points_on_route)
             .build();
         Ok(points_in_sequence)
@@ -465,13 +467,13 @@ impl<'a> OfferExporter<'a> {
 
     fn generate_point_on_route(&self, route_id: &'a str, order: usize) -> Element {
         let route_point_id = Self::generate_route_point_id(route_id, order);
-        let route_point_ref = Element::builder("RoutePointRef")
+        let route_point_ref = Element::builder("RoutePointRef", NETEX_NS)
             .attr(
                 "ref",
                 Exporter::generate_id(&route_point_id, ObjectType::RoutePoint),
             )
             .build();
-        Element::builder(ObjectType::PointOnRoute.to_string())
+        Element::builder(ObjectType::PointOnRoute.to_string(), NETEX_NS)
             .attr(
                 "id",
                 Exporter::generate_id(&route_point_id, ObjectType::PointOnRoute),
@@ -489,7 +491,7 @@ impl<'a> OfferExporter<'a> {
         stop_point: &'a StopPoint,
     ) -> Result<Element> {
         let route_point_id = Self::generate_route_point_id(route_id, order);
-        let element_builder = Element::builder(ObjectType::RoutePoint.to_string())
+        let element_builder = Element::builder(ObjectType::RoutePoint.to_string(), NETEX_NS)
             .attr(
                 "id",
                 Exporter::generate_id(&route_point_id, ObjectType::RoutePoint),
@@ -505,19 +507,19 @@ impl<'a> OfferExporter<'a> {
     }
 
     fn generate_line_ref(line_id: &str) -> Element {
-        Element::builder("LineRef")
+        Element::builder("LineRef", NETEX_NS)
             .attr("ref", Exporter::generate_id(line_id, ObjectType::Line))
             .build()
     }
 
     fn generate_route_ref(route_id: &str) -> Element {
-        Element::builder("RouteRef")
+        Element::builder("RouteRef", NETEX_NS)
             .attr("ref", Exporter::generate_id(route_id, ObjectType::Route))
             .build()
     }
 
     fn generate_scheduled_stop_point_ref(vehicle_journey_id: &'a str, sequence: u32) -> Element {
-        Element::builder("ScheduledStopPointRef")
+        Element::builder("ScheduledStopPointRef", NETEX_NS)
             .attr(
                 "ref",
                 Self::generate_stop_sequence_id(
@@ -536,39 +538,39 @@ impl<'a> OfferExporter<'a> {
     ) -> Option<Element> {
         let netex_mode = NetexMode::from_physical_mode_id(physical_mode_id)?;
         let stop_place_id = StopExporter::generate_stop_place_id(stop_area_id, netex_mode);
-        let element = Element::builder("StopPlaceRef")
+        let element = Element::builder("StopPlaceRef", NETEX_NS)
             .attr("ref", stop_place_id)
             .build();
         Some(element)
     }
 
     fn generate_quay_ref(stop_id: &'a str) -> Element {
-        Element::builder("QuayRef")
+        Element::builder("QuayRef", NETEX_NS)
             .attr("ref", Exporter::generate_id(stop_id, ObjectType::Quay))
             .build()
     }
 
     fn generate_transport_mode(netex_mode: NetexMode) -> Element {
         let transport_mode_text = Node::Text(netex_mode.to_string());
-        Element::builder("TransportMode")
+        Element::builder("TransportMode", NETEX_NS)
             .append(transport_mode_text)
             .build()
     }
 
     fn generate_day_type_ref(service_id: &'a str) -> Element {
-        let day_type_ref_element = Element::builder("DayTypeRef")
+        let day_type_ref_element = Element::builder("DayTypeRef", NETEX_NS)
             .attr(
                 "ref",
                 Exporter::generate_id(service_id, ObjectType::DayType),
             )
             .build();
-        Element::builder("dayTypes")
+        Element::builder("dayTypes", NETEX_NS)
             .append(day_type_ref_element)
             .build()
     }
 
     fn generate_journey_pattern_ref(journey_pattern_id: &'a str) -> Element {
-        Element::builder("JourneyPatternRef")
+        Element::builder("JourneyPatternRef", NETEX_NS)
             .attr(
                 "ref",
                 Exporter::generate_id(journey_pattern_id, ObjectType::ServiceJourneyPattern),
@@ -577,7 +579,7 @@ impl<'a> OfferExporter<'a> {
     }
 
     fn generate_operator_ref(company_id: &'a str) -> Element {
-        Element::builder("OperatorRef")
+        Element::builder("OperatorRef", NETEX_NS)
             .attr(
                 "ref",
                 Exporter::generate_id(company_id, ObjectType::Operator),
@@ -599,7 +601,7 @@ impl<'a> OfferExporter<'a> {
                 }
             })
             .map(|direction_type| {
-                Element::builder("DirectionType")
+                Element::builder("DirectionType", NETEX_NS)
                     .append(Node::Text(direction_type))
                     .build()
             })
@@ -616,48 +618,48 @@ impl<'a> OfferExporter<'a> {
         }
         let coord_epsg2154 = self.converter.convert(*coord)?;
         let coord_text = Node::Text(format!("{} {}", coord_epsg2154.x(), coord_epsg2154.y()));
-        let pos = Element::builder("gml:pos")
+        let pos = Element::builder("pos", GML_NS)
             .attr("srsName", "EPSG:2154")
             .append(coord_text)
             .build();
-        let location = Element::builder("Location").append(pos).build();
+        let location = Element::builder("Location", NETEX_NS).append(pos).build();
         Ok(Some(location))
     }
 
     fn generate_for_alighting(drop_off_type: u8) -> Element {
         let is_alighting = if drop_off_type == 0 { "true" } else { "false" };
-        Element::builder("ForAlighting")
+        Element::builder("ForAlighting", NETEX_NS)
             .append(Node::Text(is_alighting.to_owned()))
             .build()
     }
 
     fn generate_for_boarding(pickup_type: u8) -> Element {
         let is_boarding = if pickup_type == 0 { "true" } else { "false" };
-        Element::builder("ForBoarding")
+        Element::builder("ForBoarding", NETEX_NS)
             .append(Node::Text(is_boarding.to_owned()))
             .build()
     }
 
     fn generate_arrival_time(arrival_time: Time) -> Element {
-        Element::builder("ArrivalTime")
+        Element::builder("ArrivalTime", NETEX_NS)
             .append(Node::Text(arrival_time.to_string()))
             .build()
     }
 
     fn generate_departure_time(departure_time: Time) -> Element {
-        Element::builder("DepartureTime")
+        Element::builder("DepartureTime", NETEX_NS)
             .append(Node::Text(departure_time.to_string()))
             .build()
     }
 
     fn generate_arrival_day_offset(arrival_day_offset: u32) -> Element {
-        Element::builder("ArrivalDayOffset")
+        Element::builder("ArrivalDayOffset", NETEX_NS)
             .append(Node::Text(arrival_day_offset.to_string()))
             .build()
     }
 
     fn generate_departure_day_offset(departure_day_offset: u32) -> Element {
-        Element::builder("DepartureDayOffset")
+        Element::builder("DepartureDayOffset", NETEX_NS)
             .append(Node::Text(departure_day_offset.to_string()))
             .build()
     }

--- a/src/netex_france/transfers.rs
+++ b/src/netex_france/transfers.rs
@@ -13,7 +13,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>
 
 use crate::{
-    netex_france::exporter::{Exporter, ObjectType},
+    netex_france::{
+        exporter::{Exporter, ObjectType},
+        NETEX_NS,
+    },
     objects::Transfer,
     Model, Result,
 };
@@ -41,7 +44,7 @@ impl<'a> TransferExporter<'a> {
 // Internal methods
 impl<'a> TransferExporter<'a> {
     fn export_transfer(&self, transfer: &'a Transfer) -> Result<Element> {
-        let element_builder = Element::builder(ObjectType::SiteConnection.to_string())
+        let element_builder = Element::builder(ObjectType::SiteConnection.to_string(), NETEX_NS)
             .attr("id", self.generate_id(&transfer))
             .attr("version", "any");
         let element_builder = if let Some(walk_transfer_duration_element) =
@@ -70,19 +73,19 @@ impl<'a> TransferExporter<'a> {
         real_min_transfer_time
             .map(|time| format!("PT{}S", time))
             .map(|duration| {
-                Element::builder("DefaultDuration")
+                Element::builder("DefaultDuration", NETEX_NS)
                     .append(Node::Text(duration))
                     .build()
             })
             .map(|duration_element| {
-                Element::builder("WalkTransferDuration")
+                Element::builder("WalkTransferDuration", NETEX_NS)
                     .append(duration_element)
                     .build()
             })
     }
 
     fn generate_from(&self, from_stop_id: &'a str) -> Result<Element> {
-        let element = Element::builder("From")
+        let element = Element::builder("From", NETEX_NS)
             .append(self.generate_stop_place_ref(from_stop_id)?)
             .append(self.generate_quay_ref(from_stop_id))
             .build();
@@ -90,7 +93,7 @@ impl<'a> TransferExporter<'a> {
     }
 
     fn generate_to(&self, to_stop_id: &'a str) -> Result<Element> {
-        let element = Element::builder("To")
+        let element = Element::builder("To", NETEX_NS)
             .append(self.generate_stop_place_ref(to_stop_id)?)
             .append(self.generate_quay_ref(to_stop_id))
             .build();
@@ -109,7 +112,7 @@ impl<'a> TransferExporter<'a> {
                     stop_point_id
                 )
             })?;
-        let element = Element::builder("StopPlaceRef")
+        let element = Element::builder("StopPlaceRef", NETEX_NS)
             .attr(
                 "ref",
                 Exporter::generate_id(stop_area_id, ObjectType::StopPlace),
@@ -119,7 +122,7 @@ impl<'a> TransferExporter<'a> {
     }
 
     fn generate_quay_ref(&self, stop_point_id: &'a str) -> Element {
-        Element::builder("QuayRef")
+        Element::builder("QuayRef", NETEX_NS)
             .attr(
                 "ref",
                 Exporter::generate_id(stop_point_id, ObjectType::Quay),

--- a/src/netex_utils/mod.rs
+++ b/src/netex_utils/mod.rs
@@ -104,7 +104,7 @@ pub fn get_only_frame<'a>(frames: &'a Frames<'a>, frame_type: FrameType) -> Resu
 /// ```
 /// # use minidom::Element;
 /// # use transit_model::netex_utils::get_value_in_keylist;
-/// let xml = r#"<root>
+/// let xml = r#"<root xmlns="ns">
 ///         <KeyList>
 ///             <KeyValue>
 ///                 <Key>key</Key>
@@ -174,7 +174,7 @@ mod tests {
 
         #[test]
         fn some_frame() {
-            let xml = r#"<root>
+            let xml = r#"<root xmlns="ns">
                     <FareFrame />
                     <ServiceFrame />
                     <FareFrame />
@@ -189,7 +189,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "Failed to convert \\'UnknownFrame\\' into a FrameType")]
         fn unknown_frame() {
-            let xml = r#"<root>
+            let xml = r#"<root xmlns="ns">
                     <UnknownFrame />
                 </root>"#;
             let root: Element = xml.parse().unwrap();
@@ -235,7 +235,7 @@ mod tests {
 
         #[test]
         fn has_value() {
-            let xml = r#"<root>
+            let xml = r#"<root xmlns="ns">
                     <KeyList>
                         <KeyValue>
                             <Key>key</Key>
@@ -251,7 +251,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "No children with name \\'KeyList\\' in Element \\'root\\'")]
         fn no_keylist_found() {
-            let xml = r#"<root />"#;
+            let xml = r#"<root xmlns="ns" />"#;
             let root: Element = xml.parse().unwrap();
             get_value_in_keylist::<u32>(&root, "key").unwrap();
         }
@@ -259,7 +259,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "Failed to find a unique key \\'key\\' in \\'root\\'")]
         fn no_key_found() {
-            let xml = r#"<root>
+            let xml = r#"<root xmlns="ns">
                     <KeyList />
                 </root>"#;
             let root: Element = xml.parse().unwrap();
@@ -269,7 +269,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "No children with name \\'Value\\' in Element \\'KeyValue\\'")]
         fn no_value_found() {
-            let xml = r#"<root>
+            let xml = r#"<root xmlns="ns">
                     <KeyList>
                         <KeyValue>
                             <Key>key</Key>

--- a/tests/fixtures/netex_france/output/arrets.xml
+++ b/tests/fixtures/netex_france/output/arrets.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<PublicationDelivery version="1.09:FR-NETEX_ARRET-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
+<?xml version="1.0" encoding="utf-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.09:FR-NETEX_ARRET-2.1-1.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
 	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
@@ -24,8 +24,7 @@
 					</AccessibilityAssessment>
 					<TransportMode>rail</TransportMode>
 					<tariffZones>
-						<TariffZoneRef ref="Participant:ZoneParis">
-						</TariffZoneRef>
+						<TariffZoneRef ref="Participant:ZoneParis"/>
 					</tariffZones>
 				</Quay>
 				<Quay id="FR:Quay:GDLM:" version="any">
@@ -47,8 +46,7 @@
 					</AccessibilityAssessment>
 					<TransportMode>metro</TransportMode>
 					<tariffZones>
-						<TariffZoneRef ref="Participant:ZoneParis">
-						</TariffZoneRef>
+						<TariffZoneRef ref="Participant:ZoneParis"/>
 					</tariffZones>
 				</Quay>
 				<Quay id="FR:Quay:GDLB:" version="any">
@@ -60,8 +58,7 @@
 					</Centroid>
 					<TransportMode>bus</TransportMode>
 					<tariffZones>
-						<TariffZoneRef ref="Participant:ZoneParis">
-						</TariffZoneRef>
+						<TariffZoneRef ref="Participant:ZoneParis"/>
 					</tariffZones>
 				</Quay>
 				<Quay id="FR:Quay:NATR:" version="any">
@@ -83,8 +80,7 @@
 					</AccessibilityAssessment>
 					<TransportMode>rail</TransportMode>
 					<tariffZones>
-						<TariffZoneRef ref="Participant:ZoneParis">
-						</TariffZoneRef>
+						<TariffZoneRef ref="Participant:ZoneParis"/>
 					</tariffZones>
 				</Quay>
 				<Quay id="FR:Quay:NATM:" version="any">
@@ -96,8 +92,7 @@
 					</Centroid>
 					<TransportMode>metro</TransportMode>
 					<tariffZones>
-						<TariffZoneRef ref="Participant:ZoneParis">
-						</TariffZoneRef>
+						<TariffZoneRef ref="Participant:ZoneParis"/>
 					</tariffZones>
 				</Quay>
 				<Quay id="FR:Quay:CDGR:" version="any">
@@ -109,8 +104,7 @@
 					</Centroid>
 					<TransportMode>rail</TransportMode>
 					<tariffZones>
-						<TariffZoneRef ref="Participant:ZoneOffParis">
-						</TariffZoneRef>
+						<TariffZoneRef ref="Participant:ZoneOffParis"/>
 					</tariffZones>
 				</Quay>
 				<Quay id="FR:Quay:CDGM:" version="any">
@@ -122,8 +116,7 @@
 					</Centroid>
 					<TransportMode>metro</TransportMode>
 					<tariffZones>
-						<TariffZoneRef ref="Participant:ZoneOffParis">
-						</TariffZoneRef>
+						<TariffZoneRef ref="Participant:ZoneOffParis"/>
 					</tariffZones>
 				</Quay>
 				<Quay id="FR:Quay:DEFR:" version="any">
@@ -135,16 +128,14 @@
 					</Centroid>
 					<TransportMode>rail</TransportMode>
 					<tariffZones>
-						<TariffZoneRef ref="Participant:ZoneOffParis">
-						</TariffZoneRef>
+						<TariffZoneRef ref="Participant:ZoneOffParis"/>
 					</tariffZones>
 				</Quay>
 				<Quay id="FR:Quay:CHAM:" version="any">
 					<Name>Châtelet (Metro)</Name>
 					<TransportMode>metro</TransportMode>
 					<tariffZones>
-						<TariffZoneRef ref="Participant:ZoneParis">
-						</TariffZoneRef>
+						<TariffZoneRef ref="Participant:ZoneParis"/>
 					</tariffZones>
 					<PublicCode>The Big One</PublicCode>
 				</Quay>
@@ -157,8 +148,7 @@
 					</Centroid>
 					<TransportMode>bus</TransportMode>
 					<tariffZones>
-						<TariffZoneRef ref="Participant:ZoneParis">
-						</TariffZoneRef>
+						<TariffZoneRef ref="Participant:ZoneParis"/>
 					</tariffZones>
 				</Quay>
 				<StopPlace id="FR:StopPlace:GDL_rail:" version="any">
@@ -168,13 +158,11 @@
 							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:GDL:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:GDL:"/>
 					<TransportMode>rail</TransportMode>
 					<StopPlaceType>railStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:GDLR:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:GDLR:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:GDL_metro:" version="any">
@@ -184,13 +172,11 @@
 							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:GDL:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:GDL:"/>
 					<TransportMode>metro</TransportMode>
 					<StopPlaceType>metroStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:GDLM:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:GDLM:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:GDL_bus:" version="any">
@@ -200,15 +186,12 @@
 							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:GDL:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:GDL:"/>
 					<TransportMode>bus</TransportMode>
 					<StopPlaceType>busStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:GDLB:">
-						</QuayRef>
-						<QuayRef ref="FR:Quay:GDLR:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:GDLB:"/>
+						<QuayRef ref="FR:Quay:GDLR:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:GDL:" version="any">
@@ -250,13 +233,11 @@
 							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:NAT:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:NAT:"/>
 					<TransportMode>rail</TransportMode>
 					<StopPlaceType>railStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:NATR:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:NATR:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:NAT_metro:" version="any">
@@ -266,13 +247,11 @@
 							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:NAT:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:NAT:"/>
 					<TransportMode>metro</TransportMode>
 					<StopPlaceType>metroStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:NATM:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:NATM:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:NAT_bus:" version="any">
@@ -282,13 +261,11 @@
 							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:NAT:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:NAT:"/>
 					<TransportMode>bus</TransportMode>
 					<StopPlaceType>busStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:NATR:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:NATR:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:NAT:" version="any">
@@ -308,13 +285,11 @@
 							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:CDG:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:CDG:"/>
 					<TransportMode>rail</TransportMode>
 					<StopPlaceType>railStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:CDGR:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:CDGR:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:CDG_metro:" version="any">
@@ -324,13 +299,11 @@
 							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:CDG:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:CDG:"/>
 					<TransportMode>metro</TransportMode>
 					<StopPlaceType>metroStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:CDGM:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:CDGM:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:CDG_bus:" version="any">
@@ -340,13 +313,11 @@
 							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:CDG:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:CDG:"/>
 					<TransportMode>bus</TransportMode>
 					<StopPlaceType>busStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:CDGR:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:CDGR:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:CDG:" version="any">
@@ -378,13 +349,11 @@
 							<gml:pos srsName="EPSG:2154">644198.4609501337 6866016.318148232</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:DEF:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:DEF:"/>
 					<TransportMode>rail</TransportMode>
 					<StopPlaceType>railStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:DEFR:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:DEFR:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:DEF_bus:" version="any">
@@ -394,13 +363,11 @@
 							<gml:pos srsName="EPSG:2154">644198.4609501337 6866016.318148232</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:DEF:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:DEF:"/>
 					<TransportMode>bus</TransportMode>
 					<StopPlaceType>busStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:DEFR:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:DEFR:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:DEF:" version="any">
@@ -420,13 +387,11 @@
 							<gml:pos srsName="EPSG:2154">652172.9131210521 6862208.608972682</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:CHA:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:CHA:"/>
 					<TransportMode>metro</TransportMode>
 					<StopPlaceType>metroStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:CHAM:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:CHAM:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:CHA:" version="any">
@@ -446,13 +411,11 @@
 							<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.10406642</gml:pos>
 						</Location>
 					</Centroid>
-					<ParentSiteRef ref="FR:StopPlace:MTP:">
-					</ParentSiteRef>
+					<ParentSiteRef ref="FR:StopPlace:MTP:"/>
 					<TransportMode>bus</TransportMode>
 					<StopPlaceType>busStation</StopPlaceType>
 					<quays>
-						<QuayRef ref="FR:Quay:MTPB:">
-						</QuayRef>
+						<QuayRef ref="FR:Quay:MTPB:"/>
 					</quays>
 				</StopPlace>
 				<StopPlace id="FR:StopPlace:MTP:" version="any">

--- a/tests/fixtures/netex_france/output/calendriers.xml
+++ b/tests/fixtures/netex_france/output/calendriers.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<PublicationDelivery version="1.09:FR-NETEX_CALENDRIER-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
+<?xml version="1.0" encoding="utf-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.09:FR-NETEX_CALENDRIER-2.1-1.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
 	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
@@ -9,13 +9,10 @@
 				<ToDate>2018-12-31T23:59:59+00:00</ToDate>
 			</ValidBetween>
 			<members>
-				<DayType id="FR:DayType:Week:" version="any">
-				</DayType>
+				<DayType id="FR:DayType:Week:" version="any"/>
 				<DayTypeAssignment id="FR:DayTypeAssignment:Week:" order="0" version="any">
-					<OperatingPeriodRef ref="FR:UicOperatingPeriod:Week:">
-					</OperatingPeriodRef>
-					<DayTypeRef ref="FR:DayType:Week:">
-					</DayTypeRef>
+					<OperatingPeriodRef ref="FR:UicOperatingPeriod:Week:"/>
+					<DayTypeRef ref="FR:DayType:Week:"/>
 				</DayTypeAssignment>
 				<UicOperatingPeriod id="FR:UicOperatingPeriod:Week:" version="any">
 					<FromDate>2018-01-01T00:00:00+00:00</FromDate>

--- a/tests/fixtures/netex_france/output/correspondances.xml
+++ b/tests/fixtures/netex_france/output/correspondances.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<PublicationDelivery version="1.09:FR-NETEX_RESEAU-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
+<?xml version="1.0" encoding="utf-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.09:FR-NETEX_RESEAU-2.1-1.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
 	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
@@ -10,16 +10,12 @@
 						<DefaultDuration>PT180S</DefaultDuration>
 					</WalkTransferDuration>
 					<From>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLR:">
-						</QuayRef>
+						<StopPlaceRef ref="FR:StopPlace:GDL:"/>
+						<QuayRef ref="FR:Quay:GDLR:"/>
 					</From>
 					<To>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLM:">
-						</QuayRef>
+						<StopPlaceRef ref="FR:StopPlace:GDL:"/>
+						<QuayRef ref="FR:Quay:GDLM:"/>
 					</To>
 				</SiteConnection>
 				<SiteConnection id="FR:SiteConnection:GDLM_GDLR:" version="any">
@@ -27,16 +23,12 @@
 						<DefaultDuration>PT200S</DefaultDuration>
 					</WalkTransferDuration>
 					<From>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLM:">
-						</QuayRef>
+						<StopPlaceRef ref="FR:StopPlace:GDL:"/>
+						<QuayRef ref="FR:Quay:GDLM:"/>
 					</From>
 					<To>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLR:">
-						</QuayRef>
+						<StopPlaceRef ref="FR:StopPlace:GDL:"/>
+						<QuayRef ref="FR:Quay:GDLR:"/>
 					</To>
 				</SiteConnection>
 				<SiteConnection id="FR:SiteConnection:GDLR_GDLB:" version="any">
@@ -44,16 +36,12 @@
 						<DefaultDuration>PT600S</DefaultDuration>
 					</WalkTransferDuration>
 					<From>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLR:">
-						</QuayRef>
+						<StopPlaceRef ref="FR:StopPlace:GDL:"/>
+						<QuayRef ref="FR:Quay:GDLR:"/>
 					</From>
 					<To>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLB:">
-						</QuayRef>
+						<StopPlaceRef ref="FR:StopPlace:GDL:"/>
+						<QuayRef ref="FR:Quay:GDLB:"/>
 					</To>
 				</SiteConnection>
 				<SiteConnection id="FR:SiteConnection:GDLB_GDLR:" version="any">
@@ -61,16 +49,12 @@
 						<DefaultDuration>PT0S</DefaultDuration>
 					</WalkTransferDuration>
 					<From>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLB:">
-						</QuayRef>
+						<StopPlaceRef ref="FR:StopPlace:GDL:"/>
+						<QuayRef ref="FR:Quay:GDLB:"/>
 					</From>
 					<To>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLR:">
-						</QuayRef>
+						<StopPlaceRef ref="FR:StopPlace:GDL:"/>
+						<QuayRef ref="FR:Quay:GDLR:"/>
 					</To>
 				</SiteConnection>
 				<SiteConnection id="FR:SiteConnection:GDLM_GDLB:" version="any">
@@ -78,16 +62,12 @@
 						<DefaultDuration>PT120S</DefaultDuration>
 					</WalkTransferDuration>
 					<From>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLM:">
-						</QuayRef>
+						<StopPlaceRef ref="FR:StopPlace:GDL:"/>
+						<QuayRef ref="FR:Quay:GDLM:"/>
 					</From>
 					<To>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLB:">
-						</QuayRef>
+						<StopPlaceRef ref="FR:StopPlace:GDL:"/>
+						<QuayRef ref="FR:Quay:GDLB:"/>
 					</To>
 				</SiteConnection>
 				<SiteConnection id="FR:SiteConnection:GDLB_GDLM:" version="any">
@@ -95,16 +75,12 @@
 						<DefaultDuration>PT120S</DefaultDuration>
 					</WalkTransferDuration>
 					<From>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLB:">
-						</QuayRef>
+						<StopPlaceRef ref="FR:StopPlace:GDL:"/>
+						<QuayRef ref="FR:Quay:GDLB:"/>
 					</From>
 					<To>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLM:">
-						</QuayRef>
+						<StopPlaceRef ref="FR:StopPlace:GDL:"/>
+						<QuayRef ref="FR:Quay:GDLM:"/>
 					</To>
 				</SiteConnection>
 			</members>

--- a/tests/fixtures/netex_france/output/lignes.xml
+++ b/tests/fixtures/netex_france/output/lignes.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<PublicationDelivery version="1.09:FR-NETEX_LIGNE-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
+<?xml version="1.0" encoding="utf-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.09:FR-NETEX_LIGNE-2.1-1.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
 	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
@@ -9,12 +9,9 @@
 					<Network id="FR:Network:TGN:" version="any">
 						<Name>The Great Network</Name>
 						<members>
-							<LineRef ref="FR:Line:B42:">
-							</LineRef>
-							<LineRef ref="FR:Line:M1:">
-							</LineRef>
-							<LineRef ref="FR:Line:RERA:">
-							</LineRef>
+							<LineRef ref="FR:Line:B42:"/>
+							<LineRef ref="FR:Line:M1:"/>
+							<LineRef ref="FR:Line:RERA:"/>
 						</members>
 					</Network>
 				</ServiceFrame>

--- a/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_5cd0eea3662b0f30bd419b47ecb64840.xml
+++ b/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_5cd0eea3662b0f30bd419b47ecb64840.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<PublicationDelivery version="1.09:FR-NETEX_HORAIRE-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
+<?xml version="1.0" encoding="utf-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.09:FR-NETEX_HORAIRE-2.1-1.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
 	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
@@ -8,50 +8,40 @@
 				<Route id="FR:Route:RERA:" version="any">
 					<Name>RER A</Name>
 					<Distance>0</Distance>
-					<LineRef ref="FR:Line:RERA:">
-					</LineRef>
+					<LineRef ref="FR:Line:RERA:"/>
 					<DirectionType>inbound</DirectionType>
 					<pointsInSequence>
 						<PointOnRoute id="FR:PointOnRoute:RERA_1:" order="1" version="any">
-							<RoutePointRef ref="FR:RoutePoint:RERA_1:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:RERA_1:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:RERA_2:" order="2" version="any">
-							<RoutePointRef ref="FR:RoutePoint:RERA_2:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:RERA_2:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:RERA_3:" order="3" version="any">
-							<RoutePointRef ref="FR:RoutePoint:RERA_3:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:RERA_3:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:RERA_4:" order="4" version="any">
-							<RoutePointRef ref="FR:RoutePoint:RERA_4:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:RERA_4:"/>
 						</PointOnRoute>
 					</pointsInSequence>
 				</Route>
 				<Route id="FR:Route:RERA_Bus_R:" version="any">
 					<Name>RER A</Name>
 					<Distance>0</Distance>
-					<LineRef ref="FR:Line:RERA:">
-					</LineRef>
+					<LineRef ref="FR:Line:RERA:"/>
 					<DirectionType>outbound</DirectionType>
 					<pointsInSequence>
 						<PointOnRoute id="FR:PointOnRoute:RERA_Bus_R_1:" order="1" version="any">
-							<RoutePointRef ref="FR:RoutePoint:RERA_Bus_R_1:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:RERA_Bus_R_1:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:RERA_Bus_R_2:" order="2" version="any">
-							<RoutePointRef ref="FR:RoutePoint:RERA_Bus_R_2:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:RERA_Bus_R_2:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:RERA_Bus_R_3:" order="3" version="any">
-							<RoutePointRef ref="FR:RoutePoint:RERA_Bus_R_3:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:RERA_Bus_R_3:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:RERA_Bus_R_4:" order="4" version="any">
-							<RoutePointRef ref="FR:RoutePoint:RERA_Bus_R_4:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:RERA_Bus_R_4:"/>
 						</PointOnRoute>
 					</pointsInSequence>
 				</Route>
@@ -97,30 +87,25 @@
 				</RoutePoint>
 				<ServiceJourneyPattern id="FR:ServiceJourneyPattern:RERAF1:" version="any">
 					<Distance>0</Distance>
-					<RouteRef ref="FR:Route:RERA:">
-					</RouteRef>
+					<RouteRef ref="FR:Route:RERA:"/>
 					<pointsInSequence>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:RERAF1_1:" order="2" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_1:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_1:"/>
 							<ForAlighting>false</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:RERAF1_2:" order="3" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_2:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_2:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:RERAF1_3:" order="4" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_3:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_3:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:RERAF1_5:" order="6" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_5:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_5:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>false</ForBoarding>
 						</StopPointInJourneyPattern>
@@ -128,30 +113,25 @@
 				</ServiceJourneyPattern>
 				<ServiceJourneyPattern id="FR:ServiceJourneyPattern:RERAB1:" version="any">
 					<Distance>0</Distance>
-					<RouteRef ref="FR:Route:RERA_Bus_R:">
-					</RouteRef>
+					<RouteRef ref="FR:Route:RERA_Bus_R:"/>
 					<pointsInSequence>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:RERAB1_5:" order="6" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_5:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_5:"/>
 							<ForAlighting>false</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:RERAB1_8:" order="9" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_8:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_8:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:RERAB1_13:" order="14" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_13:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_13:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:RERAB1_21:" order="22" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_21:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_21:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>false</ForBoarding>
 						</StopPointInJourneyPattern>
@@ -198,78 +178,51 @@
 					</Location>
 				</ScheduledStopPoint>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:RERAF1_1:" order="2" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_1:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:NAT_rail:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:NATR:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_1:"/>
+					<StopPlaceRef ref="FR:StopPlace:NAT_rail:"/>
+					<QuayRef ref="FR:Quay:NATR:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:RERAF1_2:" order="3" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_2:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:GDL_rail:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:GDLR:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_2:"/>
+					<StopPlaceRef ref="FR:StopPlace:GDL_rail:"/>
+					<QuayRef ref="FR:Quay:GDLR:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:RERAF1_3:" order="4" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_3:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:CDG_rail:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:CDGR:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_3:"/>
+					<StopPlaceRef ref="FR:StopPlace:CDG_rail:"/>
+					<QuayRef ref="FR:Quay:CDGR:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:RERAF1_5:" order="6" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_5:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:DEF_rail:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:DEFR:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAF1_5:"/>
+					<StopPlaceRef ref="FR:StopPlace:DEF_rail:"/>
+					<QuayRef ref="FR:Quay:DEFR:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:RERAB1_5:" order="6" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_5:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:DEF_bus:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:DEFR:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_5:"/>
+					<StopPlaceRef ref="FR:StopPlace:DEF_bus:"/>
+					<QuayRef ref="FR:Quay:DEFR:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:RERAB1_8:" order="9" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_8:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:CDG_bus:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:CDGR:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_8:"/>
+					<StopPlaceRef ref="FR:StopPlace:CDG_bus:"/>
+					<QuayRef ref="FR:Quay:CDGR:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:RERAB1_13:" order="14" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_13:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:GDL_bus:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:GDLR:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_13:"/>
+					<StopPlaceRef ref="FR:StopPlace:GDL_bus:"/>
+					<QuayRef ref="FR:Quay:GDLR:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:RERAB1_21:" order="22" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_21:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:NAT_bus:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:NATR:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:RERAB1_21:"/>
+					<StopPlaceRef ref="FR:StopPlace:NAT_bus:"/>
+					<QuayRef ref="FR:Quay:NATR:"/>
 				</PassengerStopAssignment>
 				<ServiceJourney id="FR:ServiceJourney:RERAF1:" version="any">
 					<dayTypes>
-						<DayTypeRef ref="FR:DayType:Week:">
-						</DayTypeRef>
+						<DayTypeRef ref="FR:DayType:Week:"/>
 					</dayTypes>
-					<JourneyPatternRef ref="FR:ServiceJourneyPattern:RERAF1:">
-					</JourneyPatternRef>
-					<OperatorRef ref="FR:Operator:TGN:">
-					</OperatorRef>
+					<JourneyPatternRef ref="FR:ServiceJourneyPattern:RERAF1:"/>
+					<OperatorRef ref="FR:Operator:TGN:"/>
 					<passingTimes>
 						<TimetabledPassingTime>
 							<ArrivalTime>08:09:00</ArrivalTime>
@@ -300,13 +253,10 @@
 				<ServiceJourney id="FR:ServiceJourney:RERAB1:" version="any">
 					<TransportMode>bus</TransportMode>
 					<dayTypes>
-						<DayTypeRef ref="FR:DayType:Week:">
-						</DayTypeRef>
+						<DayTypeRef ref="FR:DayType:Week:"/>
 					</dayTypes>
-					<JourneyPatternRef ref="FR:ServiceJourneyPattern:RERAB1:">
-					</JourneyPatternRef>
-					<OperatorRef ref="FR:Operator:TGN:">
-					</OperatorRef>
+					<JourneyPatternRef ref="FR:ServiceJourneyPattern:RERAB1:"/>
+					<OperatorRef ref="FR:Operator:TGN:"/>
 					<passingTimes>
 						<TimetabledPassingTime>
 							<ArrivalTime>09:24:00</ArrivalTime>

--- a/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_MagicBus_23cdf50ee73fcba0d38beca2d8cc8c0e.xml
+++ b/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_MagicBus_23cdf50ee73fcba0d38beca2d8cc8c0e.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<PublicationDelivery version="1.09:FR-NETEX_HORAIRE-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
+<?xml version="1.0" encoding="utf-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.09:FR-NETEX_HORAIRE-2.1-1.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
 	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
@@ -8,34 +8,28 @@
 				<Route id="FR:Route:B42:" version="any">
 					<Name>Gare de Lyon - Montparnasse</Name>
 					<Distance>0</Distance>
-					<LineRef ref="FR:Line:B42:">
-					</LineRef>
+					<LineRef ref="FR:Line:B42:"/>
 					<DirectionType>inbound</DirectionType>
 					<pointsInSequence>
 						<PointOnRoute id="FR:PointOnRoute:B42_1:" order="1" version="any">
-							<RoutePointRef ref="FR:RoutePoint:B42_1:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:B42_1:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:B42_2:" order="2" version="any">
-							<RoutePointRef ref="FR:RoutePoint:B42_2:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:B42_2:"/>
 						</PointOnRoute>
 					</pointsInSequence>
 				</Route>
 				<Route id="FR:Route:B42_R:" version="any">
 					<Name>Montparnasse - Gare de Lyon</Name>
 					<Distance>0</Distance>
-					<LineRef ref="FR:Line:B42:">
-					</LineRef>
+					<LineRef ref="FR:Line:B42:"/>
 					<DirectionType>outbound</DirectionType>
 					<pointsInSequence>
 						<PointOnRoute id="FR:PointOnRoute:B42_R_1:" order="1" version="any">
-							<RoutePointRef ref="FR:RoutePoint:B42_R_1:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:B42_R_1:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:B42_R_2:" order="2" version="any">
-							<RoutePointRef ref="FR:RoutePoint:B42_R_2:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:B42_R_2:"/>
 						</PointOnRoute>
 					</pointsInSequence>
 				</Route>
@@ -61,18 +55,15 @@
 				</RoutePoint>
 				<ServiceJourneyPattern id="FR:ServiceJourneyPattern:B42F1:" version="any">
 					<Distance>0</Distance>
-					<RouteRef ref="FR:Route:B42:">
-					</RouteRef>
+					<RouteRef ref="FR:Route:B42:"/>
 					<pointsInSequence>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:B42F1_10:" order="11" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42F1_10:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42F1_10:"/>
 							<ForAlighting>false</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:B42F1_20:" order="21" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42F1_20:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42F1_20:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>false</ForBoarding>
 						</StopPointInJourneyPattern>
@@ -80,18 +71,15 @@
 				</ServiceJourneyPattern>
 				<ServiceJourneyPattern id="FR:ServiceJourneyPattern:B42B1:" version="any">
 					<Distance>0</Distance>
-					<RouteRef ref="FR:Route:B42_R:">
-					</RouteRef>
+					<RouteRef ref="FR:Route:B42_R:"/>
 					<pointsInSequence>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:B42B1_20:" order="21" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42B1_20:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42B1_20:"/>
 							<ForAlighting>false</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:B42B1_30:" order="31" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42B1_30:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42B1_30:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>false</ForBoarding>
 						</StopPointInJourneyPattern>
@@ -118,46 +106,31 @@
 					</Location>
 				</ScheduledStopPoint>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:B42F1_10:" order="11" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42F1_10:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:GDL_bus:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:GDLB:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42F1_10:"/>
+					<StopPlaceRef ref="FR:StopPlace:GDL_bus:"/>
+					<QuayRef ref="FR:Quay:GDLB:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:B42F1_20:" order="21" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42F1_20:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:MTP_bus:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:MTPB:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42F1_20:"/>
+					<StopPlaceRef ref="FR:StopPlace:MTP_bus:"/>
+					<QuayRef ref="FR:Quay:MTPB:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:B42B1_20:" order="21" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42B1_20:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:MTP_bus:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:MTPB:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42B1_20:"/>
+					<StopPlaceRef ref="FR:StopPlace:MTP_bus:"/>
+					<QuayRef ref="FR:Quay:MTPB:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:B42B1_30:" order="31" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42B1_30:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:GDL_bus:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:GDLB:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:B42B1_30:"/>
+					<StopPlaceRef ref="FR:StopPlace:GDL_bus:"/>
+					<QuayRef ref="FR:Quay:GDLB:"/>
 				</PassengerStopAssignment>
 				<ServiceJourney id="FR:ServiceJourney:B42F1:" version="any">
 					<dayTypes>
-						<DayTypeRef ref="FR:DayType:Week:">
-						</DayTypeRef>
+						<DayTypeRef ref="FR:DayType:Week:"/>
 					</dayTypes>
-					<JourneyPatternRef ref="FR:ServiceJourneyPattern:B42F1:">
-					</JourneyPatternRef>
-					<OperatorRef ref="FR:Operator:TGN:">
-					</OperatorRef>
+					<JourneyPatternRef ref="FR:ServiceJourneyPattern:B42F1:"/>
+					<OperatorRef ref="FR:Operator:TGN:"/>
 					<passingTimes>
 						<TimetabledPassingTime>
 							<ArrivalTime>10:10:00</ArrivalTime>
@@ -175,13 +148,10 @@
 				</ServiceJourney>
 				<ServiceJourney id="FR:ServiceJourney:B42B1:" version="any">
 					<dayTypes>
-						<DayTypeRef ref="FR:DayType:Week:">
-						</DayTypeRef>
+						<DayTypeRef ref="FR:DayType:Week:"/>
 					</dayTypes>
-					<JourneyPatternRef ref="FR:ServiceJourneyPattern:B42B1:">
-					</JourneyPatternRef>
-					<OperatorRef ref="FR:Operator:TGN:">
-					</OperatorRef>
+					<JourneyPatternRef ref="FR:ServiceJourneyPattern:B42B1:"/>
+					<OperatorRef ref="FR:Operator:TGN:"/>
 					<passingTimes>
 						<TimetabledPassingTime>
 							<ArrivalTime>07:00:00</ArrivalTime>

--- a/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_f31e1eef20f64733a18c538073e78396.xml
+++ b/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_f31e1eef20f64733a18c538073e78396.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<PublicationDelivery version="1.09:FR-NETEX_HORAIRE-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
+<?xml version="1.0" encoding="utf-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.09:FR-NETEX_HORAIRE-2.1-1.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
 	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
@@ -8,50 +8,40 @@
 				<Route id="FR:Route:M1:" version="any">
 					<Name>Nation - Charles de Gaulle</Name>
 					<Distance>0</Distance>
-					<LineRef ref="FR:Line:M1:">
-					</LineRef>
+					<LineRef ref="FR:Line:M1:"/>
 					<DirectionType>inbound</DirectionType>
 					<pointsInSequence>
 						<PointOnRoute id="FR:PointOnRoute:M1_1:" order="1" version="any">
-							<RoutePointRef ref="FR:RoutePoint:M1_1:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:M1_1:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:M1_2:" order="2" version="any">
-							<RoutePointRef ref="FR:RoutePoint:M1_2:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:M1_2:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:M1_3:" order="3" version="any">
-							<RoutePointRef ref="FR:RoutePoint:M1_3:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:M1_3:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:M1_4:" order="4" version="any">
-							<RoutePointRef ref="FR:RoutePoint:M1_4:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:M1_4:"/>
 						</PointOnRoute>
 					</pointsInSequence>
 				</Route>
 				<Route id="FR:Route:M1_R:" version="any">
 					<Name>Charles de Gaulle - Nation</Name>
 					<Distance>0</Distance>
-					<LineRef ref="FR:Line:M1:">
-					</LineRef>
+					<LineRef ref="FR:Line:M1:"/>
 					<DirectionType>outbound</DirectionType>
 					<pointsInSequence>
 						<PointOnRoute id="FR:PointOnRoute:M1_R_1:" order="1" version="any">
-							<RoutePointRef ref="FR:RoutePoint:M1_R_1:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:M1_R_1:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:M1_R_2:" order="2" version="any">
-							<RoutePointRef ref="FR:RoutePoint:M1_R_2:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:M1_R_2:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:M1_R_3:" order="3" version="any">
-							<RoutePointRef ref="FR:RoutePoint:M1_R_3:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:M1_R_3:"/>
 						</PointOnRoute>
 						<PointOnRoute id="FR:PointOnRoute:M1_R_4:" order="4" version="any">
-							<RoutePointRef ref="FR:RoutePoint:M1_R_4:">
-							</RoutePointRef>
+							<RoutePointRef ref="FR:RoutePoint:M1_R_4:"/>
 						</PointOnRoute>
 					</pointsInSequence>
 				</Route>
@@ -65,8 +55,7 @@
 						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
 					</Location>
 				</RoutePoint>
-				<RoutePoint id="FR:RoutePoint:M1_3:" version="any">
-				</RoutePoint>
+				<RoutePoint id="FR:RoutePoint:M1_3:" version="any"/>
 				<RoutePoint id="FR:RoutePoint:M1_4:" version="any">
 					<Location>
 						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
@@ -77,8 +66,7 @@
 						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
 					</Location>
 				</RoutePoint>
-				<RoutePoint id="FR:RoutePoint:M1_R_2:" version="any">
-				</RoutePoint>
+				<RoutePoint id="FR:RoutePoint:M1_R_2:" version="any"/>
 				<RoutePoint id="FR:RoutePoint:M1_R_3:" version="any">
 					<Location>
 						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
@@ -91,30 +79,25 @@
 				</RoutePoint>
 				<ServiceJourneyPattern id="FR:ServiceJourneyPattern:M1F1:" version="any">
 					<Distance>0</Distance>
-					<RouteRef ref="FR:Route:M1:">
-					</RouteRef>
+					<RouteRef ref="FR:Route:M1:"/>
 					<pointsInSequence>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:M1F1_0:" order="1" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_0:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_0:"/>
 							<ForAlighting>false</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:M1F1_1:" order="2" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_1:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_1:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:M1F1_2:" order="3" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_2:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_2:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:M1F1_3:" order="4" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_3:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_3:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>false</ForBoarding>
 						</StopPointInJourneyPattern>
@@ -122,30 +105,25 @@
 				</ServiceJourneyPattern>
 				<ServiceJourneyPattern id="FR:ServiceJourneyPattern:M1B1:" version="any">
 					<Distance>0</Distance>
-					<RouteRef ref="FR:Route:M1_R:">
-					</RouteRef>
+					<RouteRef ref="FR:Route:M1_R:"/>
 					<pointsInSequence>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:M1B1_6:" order="7" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_6:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_6:"/>
 							<ForAlighting>false</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:M1B1_7:" order="8" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_7:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_7:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:M1B1_8:" order="9" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_8:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_8:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>true</ForBoarding>
 						</StopPointInJourneyPattern>
 						<StopPointInJourneyPattern id="FR:StopPointInJourneyPattern:M1B1_9:" order="10" version="any">
-							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_9:">
-							</ScheduledStopPointRef>
+							<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_9:"/>
 							<ForAlighting>true</ForAlighting>
 							<ForBoarding>false</ForBoarding>
 						</StopPointInJourneyPattern>
@@ -161,8 +139,7 @@
 						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
-				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1F1_2:" version="any">
-				</ScheduledStopPoint>
+				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1F1_2:" version="any"/>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1F1_3:" version="any">
 					<Location>
 						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
@@ -173,8 +150,7 @@
 						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
-				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1B1_7:" version="any">
-				</ScheduledStopPoint>
+				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1B1_7:" version="any"/>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1B1_8:" version="any">
 					<Location>
 						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
@@ -186,78 +162,51 @@
 					</Location>
 				</ScheduledStopPoint>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:M1F1_0:" order="1" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_0:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:NAT_metro:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:NATM:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_0:"/>
+					<StopPlaceRef ref="FR:StopPlace:NAT_metro:"/>
+					<QuayRef ref="FR:Quay:NATM:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:M1F1_1:" order="2" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_1:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:GDL_metro:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:GDLM:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_1:"/>
+					<StopPlaceRef ref="FR:StopPlace:GDL_metro:"/>
+					<QuayRef ref="FR:Quay:GDLM:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:M1F1_2:" order="3" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_2:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:CHA_metro:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:CHAM:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_2:"/>
+					<StopPlaceRef ref="FR:StopPlace:CHA_metro:"/>
+					<QuayRef ref="FR:Quay:CHAM:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:M1F1_3:" order="4" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_3:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:CDG_metro:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:CDGM:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1F1_3:"/>
+					<StopPlaceRef ref="FR:StopPlace:CDG_metro:"/>
+					<QuayRef ref="FR:Quay:CDGM:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:M1B1_6:" order="7" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_6:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:CDG_metro:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:CDGM:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_6:"/>
+					<StopPlaceRef ref="FR:StopPlace:CDG_metro:"/>
+					<QuayRef ref="FR:Quay:CDGM:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:M1B1_7:" order="8" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_7:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:CHA_metro:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:CHAM:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_7:"/>
+					<StopPlaceRef ref="FR:StopPlace:CHA_metro:"/>
+					<QuayRef ref="FR:Quay:CHAM:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:M1B1_8:" order="9" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_8:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:GDL_metro:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:GDLM:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_8:"/>
+					<StopPlaceRef ref="FR:StopPlace:GDL_metro:"/>
+					<QuayRef ref="FR:Quay:GDLM:"/>
 				</PassengerStopAssignment>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:M1B1_9:" order="10" version="any">
-					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_9:">
-					</ScheduledStopPointRef>
-					<StopPlaceRef ref="FR:StopPlace:NAT_metro:">
-					</StopPlaceRef>
-					<QuayRef ref="FR:Quay:NATM:">
-					</QuayRef>
+					<ScheduledStopPointRef ref="FR:ScheduledStopPoint:M1B1_9:"/>
+					<StopPlaceRef ref="FR:StopPlace:NAT_metro:"/>
+					<QuayRef ref="FR:Quay:NATM:"/>
 				</PassengerStopAssignment>
 				<ServiceJourney id="FR:ServiceJourney:M1F1:" version="any">
 					<dayTypes>
-						<DayTypeRef ref="FR:DayType:Week:">
-						</DayTypeRef>
+						<DayTypeRef ref="FR:DayType:Week:"/>
 					</dayTypes>
-					<JourneyPatternRef ref="FR:ServiceJourneyPattern:M1F1:">
-					</JourneyPatternRef>
-					<OperatorRef ref="FR:Operator:TGN:">
-					</OperatorRef>
+					<JourneyPatternRef ref="FR:ServiceJourneyPattern:M1F1:"/>
+					<OperatorRef ref="FR:Operator:TGN:"/>
 					<passingTimes>
 						<TimetabledPassingTime>
 							<ArrivalTime>00:00:00</ArrivalTime>
@@ -287,13 +236,10 @@
 				</ServiceJourney>
 				<ServiceJourney id="FR:ServiceJourney:M1B1:" version="any">
 					<dayTypes>
-						<DayTypeRef ref="FR:DayType:Week:">
-						</DayTypeRef>
+						<DayTypeRef ref="FR:DayType:Week:"/>
 					</dayTypes>
-					<JourneyPatternRef ref="FR:ServiceJourneyPattern:M1B1:">
-					</JourneyPatternRef>
-					<OperatorRef ref="FR:Operator:TGN:">
-					</OperatorRef>
+					<JourneyPatternRef ref="FR:ServiceJourneyPattern:M1B1:"/>
+					<OperatorRef ref="FR:Operator:TGN:"/>
 					<passingTimes>
 						<TimetabledPassingTime>
 							<ArrivalTime>00:00:00</ArrivalTime>


### PR DESCRIPTION
This PR depends on https://github.com/CanalTP/minidom_ext/pull/6.

I'm removing entirely the dependence on `minidom_writer` and uses the already available APIs from `minidom` in order to write XML files. A few modifications to the fixtures had to be done but their only formatting differences, not semantic.

I also removed `quick_xml` from `Cargo.toml` (see https://github.com/CanalTP/minidom_ext/pull/6 for the explanation).