### PR TITLE
[fix] do not depend on time anymore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ xmllint = ["proj"]
 mutable-model = []
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 chrono-tz = { version = "0.5", features = ["serde"] }
 csv = "1"
 derivative = "2"

--- a/gtfs2netexfr/Cargo.toml
+++ b/gtfs2netexfr/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "data-structures", "encoding", "parser-i
 keywords = ["gtfs", "netex", "transit"]
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 failure = "0.1"
 structopt = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }

--- a/gtfs2ntfs/Cargo.toml
+++ b/gtfs2ntfs/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "data-structures", "encoding", "parser-i
 keywords = ["gtfs", "ntfs", "transit"]
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 failure = "0.1"
 structopt = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }

--- a/ntfs2gtfs/Cargo.toml
+++ b/ntfs2gtfs/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "data-structures", "encoding", "parser-i
 keywords = ["gtfs", "ntfs", "transit"]
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 failure = "0.1"
 structopt = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }

--- a/ntfs2netexfr/Cargo.toml
+++ b/ntfs2netexfr/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "data-structures", "encoding", "parser-i
 keywords = ["ntfs", "netex", "transit"]
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 failure = "0.1"
 structopt = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }

--- a/ntfs2ntfs/Cargo.toml
+++ b/ntfs2ntfs/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "data-structures", "encoding", "parser-i
 keywords = ["ntfs", "transit"]
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 failure = "0.1"
 structopt = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }

--- a/restrict-validity-period/Cargo.toml
+++ b/restrict-validity-period/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "data-structures", "encoding", "parser-i
 keywords = ["ntfs", "transit"]
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 structopt = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 tracing-log = "0.1"


### PR DESCRIPTION
Remove `default-features` from `chrono`, which brings `time` (through feature [`oldtime`](https://github.com/chronotope/chrono/blob/v0.4.19/Cargo.toml#L31)) as a dependency in a version affected by [`RUSTSEC-2020-0071`](https://rustsec.org/advisories/RUSTSEC-2020-0071). :warning: Note that this is not a workaround for the advisory [`RUSTSEC-2020-0159`](https://rustsec.org/advisories/RUSTSEC-2020-0159) concerning `chrono` (see [this comment](https://github.com/time-rs/time/issues/293#issuecomment-946382614) for details).