### PR TITLE
feat: remove 'chrono' as a direct dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.46.0"
+version = "0.47.0"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"
@@ -39,7 +39,6 @@ mutable-model = []
 
 [dependencies]
 anyhow = "1"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 chrono-tz = { version = "0.6", features = ["serde"] }
 csv = "1"
 derivative = "2"
@@ -63,6 +62,7 @@ serde_json = "1"
 skip_error = { version = "3.1", features = ["tracing"] }
 tempfile = "3"
 thiserror = "1"
+time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 typed_index_collection = "2"
 walkdir = "2"

--- a/gtfs2netexfr/Cargo.toml
+++ b/gtfs2netexfr/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["gtfs", "netex", "transit"]
 
 [dependencies]
 anyhow = "1"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 structopt = "0.3"
+time = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 tracing-log = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 transit_model = { path = "../", features = ["proj"] }
 lazy_static = "1"
 

--- a/gtfs2netexfr/src/main.rs
+++ b/gtfs2netexfr/src/main.rs
@@ -14,9 +14,9 @@
 // along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 
-use chrono::{DateTime, FixedOffset};
 use std::path::PathBuf;
 use structopt::StructOpt;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tracing::info;
 use tracing_subscriber::{
     filter::{EnvFilter, LevelFilter},
@@ -31,6 +31,10 @@ lazy_static::lazy_static! {
 
 fn get_version() -> &'static str {
     &GIT_VERSION
+}
+
+fn parse_offset_datetime(offset_date_time: &str) -> Result<OffsetDateTime, time::error::Parse> {
+    OffsetDateTime::parse(offset_date_time, &Rfc3339)
 }
 
 #[derive(Debug, StructOpt)]
@@ -78,10 +82,10 @@ struct Opt {
     #[structopt(
         short = "x",
         long,
-        parse(try_from_str),
+        parse(try_from_str = parse_offset_datetime),
         default_value = &transit_model::CURRENT_DATETIME
     )]
-    current_datetime: DateTime<FixedOffset>,
+    current_datetime: time::OffsetDateTime,
 }
 
 fn init_logger() {

--- a/gtfs2ntfs/Cargo.toml
+++ b/gtfs2ntfs/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["gtfs", "ntfs", "transit"]
 
 [dependencies]
 anyhow = "1"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 structopt = "0.3"
+time = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 tracing-log = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 transit_model = { path = "../" }
 lazy_static = "1"
 

--- a/gtfs2ntfs/src/main.rs
+++ b/gtfs2ntfs/src/main.rs
@@ -14,9 +14,9 @@
 // along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 
-use chrono::{DateTime, FixedOffset};
 use std::path::PathBuf;
 use structopt::StructOpt;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tracing::info;
 use tracing_subscriber::{
     filter::{EnvFilter, LevelFilter},
@@ -31,6 +31,10 @@ lazy_static::lazy_static! {
 
 fn get_version() -> &'static str {
     &GIT_VERSION
+}
+
+fn parse_offset_datetime(offset_date_time: &str) -> Result<OffsetDateTime, time::error::Parse> {
+    OffsetDateTime::parse(offset_date_time, &Rfc3339)
 }
 
 #[derive(Debug, StructOpt)]
@@ -78,10 +82,10 @@ struct Opt {
     #[structopt(
         short = "x",
         long,
-        parse(try_from_str),
+        parse(try_from_str = parse_offset_datetime),
         default_value = &transit_model::CURRENT_DATETIME
     )]
-    current_datetime: DateTime<FixedOffset>,
+    current_datetime: OffsetDateTime,
 
     /// The maximum distance in meters to compute the tranfer.
     #[structopt(long, short = "d", default_value = transit_model::TRANSFER_MAX_DISTANCE)]

--- a/model-builder/Cargo.toml
+++ b/model-builder/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["data-structures"]
 keywords = ["transit"]
 
 [dependencies]
+time = { version = "0.3", features = ["macros", "parsing"]}
 # Swap the next two lines when publishing
 # transit_model = "0.6"
 transit_model = { path = "../" }

--- a/ntfs2gtfs/Cargo.toml
+++ b/ntfs2gtfs/Cargo.toml
@@ -13,11 +13,10 @@ keywords = ["gtfs", "ntfs", "transit"]
 
 [dependencies]
 anyhow = "1"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 structopt = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 tracing-log = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 transit_model = { path = "../" }
 lazy_static = "1"
 

--- a/ntfs2netexfr/Cargo.toml
+++ b/ntfs2netexfr/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["ntfs", "netex", "transit"]
 
 [dependencies]
 anyhow = "1"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 structopt = "0.3"
+time = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 tracing-log = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 transit_model = { path = "../", features = ["proj"] }
 lazy_static = "1"
 

--- a/ntfs2netexfr/src/main.rs
+++ b/ntfs2netexfr/src/main.rs
@@ -14,9 +14,9 @@
 // along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 
-use chrono::{DateTime, FixedOffset};
 use std::path::PathBuf;
 use structopt::StructOpt;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tracing::info;
 use tracing_subscriber::{
     filter::{EnvFilter, LevelFilter},
@@ -31,6 +31,10 @@ lazy_static::lazy_static! {
 
 fn get_version() -> &'static str {
     &GIT_VERSION
+}
+
+fn parse_offset_datetime(offset_date_time: &str) -> Result<OffsetDateTime, time::error::Parse> {
+    OffsetDateTime::parse(offset_date_time, &Rfc3339)
 }
 
 #[derive(Debug, StructOpt)]
@@ -62,10 +66,10 @@ struct Opt {
     #[structopt(
         short = "x",
         long,
-        parse(try_from_str),
+        parse(try_from_str = parse_offset_datetime),
         default_value = &transit_model::CURRENT_DATETIME
     )]
-    current_datetime: DateTime<FixedOffset>,
+    current_datetime: time::OffsetDateTime,
 }
 
 fn init_logger() {

--- a/ntfs2ntfs/Cargo.toml
+++ b/ntfs2ntfs/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["ntfs", "transit"]
 
 [dependencies]
 anyhow = "1"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 structopt = "0.3"
+time = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 tracing-log = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 transit_model = { path = "../" }
 lazy_static = "1"
 

--- a/ntfs2ntfs/src/main.rs
+++ b/ntfs2ntfs/src/main.rs
@@ -14,9 +14,9 @@
 // along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 
-use chrono::{DateTime, FixedOffset};
 use std::path::PathBuf;
 use structopt::StructOpt;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tracing::info;
 use tracing_subscriber::{
     filter::{EnvFilter, LevelFilter},
@@ -31,6 +31,10 @@ lazy_static::lazy_static! {
 
 fn get_version() -> &'static str {
     &GIT_VERSION
+}
+
+fn parse_offset_datetime(offset_date_time: &str) -> Result<OffsetDateTime, time::error::Parse> {
+    OffsetDateTime::parse(offset_date_time, &Rfc3339)
 }
 
 #[derive(Debug, StructOpt)]
@@ -48,10 +52,10 @@ struct Opt {
     #[structopt(
         short = "x",
         long,
-        parse(try_from_str),
+        parse(try_from_str = parse_offset_datetime),
         default_value = &transit_model::CURRENT_DATETIME
     )]
-    current_datetime: DateTime<FixedOffset>,
+    current_datetime: time::OffsetDateTime,
 
     /// The maximum distance in meters to compute the tranfer.
     #[structopt(long, short = "d", default_value = transit_model::TRANSFER_MAX_DISTANCE)]

--- a/restrict-validity-period/Cargo.toml
+++ b/restrict-validity-period/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["command-line-utilities", "data-structures", "encoding", "parser-i
 keywords = ["ntfs", "transit"]
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 structopt = "0.3"
+time = { version = "0.3", features = ["macros", "parsing"] }
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 tracing-log = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 transit_model = { path = "../" }

--- a/src/enhancers/enhance_pickup_dropoff.rs
+++ b/src/enhancers/enhance_pickup_dropoff.rs
@@ -167,9 +167,10 @@ pub fn enhance_pickup_dropoff(collections: &mut Collections) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::objects::{Calendar, Date, StopPoint, Time};
+    use crate::objects::{Calendar, StopPoint, Time};
     use pretty_assertions::assert_eq;
     use std::collections::BTreeSet;
+    use time::{Date, Month};
     use typed_index_collection::CollectionWithId;
 
     // For testing, we need to configure:
@@ -318,7 +319,7 @@ mod tests {
         );
         collections.vehicle_journeys = build_vehicle_journeys(prev_vj_config, next_vj_config);
         let mut dates = BTreeSet::new();
-        dates.insert(Date::from_ymd(2020, 1, 1));
+        dates.insert(Date::from_calendar_date(2020, Month::January, 1).unwrap());
         collections.calendars = CollectionWithId::new(vec![Calendar {
             id: "default_service".to_owned(),
             dates,
@@ -359,7 +360,7 @@ mod tests {
         );
         collections.vehicle_journeys = build_vehicle_journeys(prev_vj_config, next_vj_config);
         let mut dates = BTreeSet::new();
-        dates.insert(Date::from_ymd(2020, 1, 1));
+        dates.insert(Date::from_calendar_date(2020, Month::January, 1).unwrap());
         collections.calendars = CollectionWithId::new(vec![Calendar {
             id: "default_service".to_owned(),
             dates,
@@ -400,7 +401,7 @@ mod tests {
         );
         collections.vehicle_journeys = build_vehicle_journeys(prev_vj_config, next_vj_config);
         let mut dates = BTreeSet::new();
-        dates.insert(Date::from_ymd(2020, 1, 1));
+        dates.insert(Date::from_calendar_date(2020, Month::January, 1).unwrap());
         collections.calendars = CollectionWithId::new(vec![Calendar {
             id: "default_service".to_owned(),
             dates,
@@ -464,7 +465,7 @@ mod tests {
         });
         drop(vj_mut);
         let mut dates = BTreeSet::new();
-        dates.insert(Date::from_ymd(2020, 1, 1));
+        dates.insert(Date::from_calendar_date(2020, Month::January, 1).unwrap());
         collections.calendars = CollectionWithId::new(vec![Calendar {
             id: "default_service".to_owned(),
             dates,

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -38,6 +38,7 @@ use std::{
     cmp,
     collections::{BTreeMap, BTreeSet, HashMap},
 };
+use time::Duration;
 use tracing::{info, warn};
 use typed_index_collection::{impl_id, Collection, CollectionWithId, Idx};
 
@@ -1258,7 +1259,7 @@ where
                     let new_dates: BTreeSet<_> = service
                         .dates
                         .iter()
-                        .map(|d| *d + chrono::Duration::days(i64::from(nb_days)))
+                        .map(|d| *d + Duration::days(i64::from(nb_days)))
                         .collect();
 
                     let new_service = objects::Calendar {
@@ -1356,6 +1357,7 @@ mod tests {
     };
     use geo::line_string;
     use pretty_assertions::assert_eq;
+    use time::{Date, Month};
     use typed_index_collection::Id;
 
     fn extract<'a, T, S: ::std::cmp::Ord>(f: fn(&'a T) -> S, c: &'a Collection<T>) -> Vec<S> {
@@ -2825,8 +2827,8 @@ mod tests {
             calendars::manage_calendars(&mut handler, &mut collections).unwrap();
 
             let mut dates = BTreeSet::new();
-            dates.insert(chrono::NaiveDate::from_ymd(2018, 5, 5));
-            dates.insert(chrono::NaiveDate::from_ymd(2018, 5, 6));
+            dates.insert(Date::from_calendar_date(2018, Month::May, 5).unwrap());
+            dates.insert(Date::from_calendar_date(2018, Month::May, 6).unwrap());
             assert_eq!(
                 vec![Calendar {
                     id: "1".to_string(),
@@ -2852,7 +2854,7 @@ mod tests {
             calendars::manage_calendars(&mut handler, &mut collections).unwrap();
 
             let mut dates = BTreeSet::new();
-            dates.insert(chrono::NaiveDate::from_ymd(2018, 2, 12));
+            dates.insert(Date::from_calendar_date(2018, Month::February, 12).unwrap());
             assert_eq!(
                 vec![Calendar {
                     id: "1".to_string(),
@@ -2884,8 +2886,8 @@ mod tests {
             calendars::manage_calendars(&mut handler, &mut collections).unwrap();
 
             let mut dates = BTreeSet::new();
-            dates.insert(chrono::NaiveDate::from_ymd(2018, 5, 6));
-            dates.insert(chrono::NaiveDate::from_ymd(2018, 5, 7));
+            dates.insert(Date::from_calendar_date(2018, Month::May, 6).unwrap());
+            dates.insert(Date::from_calendar_date(2018, Month::May, 7).unwrap());
             assert_eq!(
                 vec![
                     Calendar {

--- a/src/gtfs/write.rs
+++ b/src/gtfs/write.rs
@@ -508,6 +508,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use std::{collections::BTreeSet, fs::File, io::Read};
     use tempfile::tempdir;
+    use time::{Date, Month};
 
     #[test]
     fn write_agency() {
@@ -839,7 +840,7 @@ mod tests {
             })
             .unwrap();
         let mut dates = BTreeSet::new();
-        dates.insert(chrono::NaiveDate::from_ymd(2018, 5, 6));
+        dates.insert(Date::from_calendar_date(2018, Month::May, 6).unwrap());
         collections
             .calendars
             .push(objects::Calendar {
@@ -1118,9 +1119,9 @@ mod tests {
     fn write_calendar_file_from_calendar() {
         let mut dates = BTreeSet::new();
         //saturday
-        dates.insert(chrono::NaiveDate::from_ymd(2018, 5, 5));
+        dates.insert(Date::from_calendar_date(2018, Month::May, 5).unwrap());
         //sunday
-        dates.insert(chrono::NaiveDate::from_ymd(2018, 5, 6));
+        dates.insert(Date::from_calendar_date(2018, Month::May, 6).unwrap());
         let calendar = CollectionWithId::new(vec![
             Calendar {
                 id: "1".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub const TRANSFER_WAITING_TIME: &str = "60";
 
 lazy_static::lazy_static! {
     /// Current datetime
-    pub static ref CURRENT_DATETIME: String = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    pub static ref CURRENT_DATETIME: String = time::OffsetDateTime::now_utc().format(&time::format_description::well_known::Rfc3339).unwrap();
 }
 
 /// The error type used by the crate.

--- a/src/model.rs
+++ b/src/model.rs
@@ -16,7 +16,6 @@
 
 use crate::{enhancers, objects::*, Error, Result};
 use anyhow::{anyhow, bail};
-use chrono::NaiveDate;
 use derivative::Derivative;
 use geo::algorithm::centroid::Centroid;
 use geo::MultiPoint;
@@ -30,6 +29,7 @@ use std::{
     hash::{Hash, Hasher},
     ops,
 };
+use time::Date;
 use tracing::{debug, warn};
 use typed_index_collection::{Collection, CollectionWithId, Id, Idx};
 
@@ -147,7 +147,7 @@ impl Collections {
     }
 
     /// Restrict the validity period of the current `Collections` with the start_date and end_date
-    pub fn restrict_period(&mut self, start_date: NaiveDate, end_date: NaiveDate) -> Result<()> {
+    pub fn restrict_period(&mut self, start_date: Date, end_date: Date) -> Result<()> {
         let mut calendars = self.calendars.take();
         for calendar in calendars.iter_mut() {
             calendar.dates = calendar
@@ -1568,29 +1568,52 @@ mod tests {
     mod calendar_deduplication {
         use super::*;
         use pretty_assertions::assert_eq;
+        use time::Month;
 
         #[test]
         fn enhance() {
             let mut collections = Collections::default();
 
             let mut service_1 = Calendar::new(String::from("service_1"));
-            service_1.dates.insert(NaiveDate::from_ymd(2019, 10, 1));
-            service_1.dates.insert(NaiveDate::from_ymd(2019, 10, 2));
-            service_1.dates.insert(NaiveDate::from_ymd(2019, 10, 3));
-            service_1.dates.insert(NaiveDate::from_ymd(2019, 10, 10));
+            service_1
+                .dates
+                .insert(Date::from_calendar_date(2019, Month::October, 1).unwrap());
+            service_1
+                .dates
+                .insert(Date::from_calendar_date(2019, Month::October, 2).unwrap());
+            service_1
+                .dates
+                .insert(Date::from_calendar_date(2019, Month::October, 3).unwrap());
+            service_1
+                .dates
+                .insert(Date::from_calendar_date(2019, Month::October, 10).unwrap());
             collections.calendars.push(service_1).unwrap();
 
             let mut service_2 = Calendar::new(String::from("service_2"));
-            service_2.dates.insert(NaiveDate::from_ymd(2019, 10, 1));
-            service_2.dates.insert(NaiveDate::from_ymd(2019, 10, 2));
-            service_2.dates.insert(NaiveDate::from_ymd(2019, 10, 3));
-            service_2.dates.insert(NaiveDate::from_ymd(2019, 10, 10));
+            service_2
+                .dates
+                .insert(Date::from_calendar_date(2019, Month::October, 1).unwrap());
+            service_2
+                .dates
+                .insert(Date::from_calendar_date(2019, Month::October, 2).unwrap());
+            service_2
+                .dates
+                .insert(Date::from_calendar_date(2019, Month::October, 3).unwrap());
+            service_2
+                .dates
+                .insert(Date::from_calendar_date(2019, Month::October, 10).unwrap());
             collections.calendars.push(service_2).unwrap();
 
             let mut service_3 = Calendar::new(String::from("service_3"));
-            service_3.dates.insert(NaiveDate::from_ymd(2019, 10, 1));
-            service_3.dates.insert(NaiveDate::from_ymd(2019, 10, 3));
-            service_3.dates.insert(NaiveDate::from_ymd(2019, 10, 10));
+            service_3
+                .dates
+                .insert(Date::from_calendar_date(2019, Month::October, 1).unwrap());
+            service_3
+                .dates
+                .insert(Date::from_calendar_date(2019, Month::October, 3).unwrap());
+            service_3
+                .dates
+                .insert(Date::from_calendar_date(2019, Month::October, 10).unwrap());
             collections.calendars.push(service_3).unwrap();
 
             collections

--- a/src/netex_france/mod.rs
+++ b/src/netex_france/mod.rs
@@ -37,7 +37,7 @@ mod transfers;
 use transfers::TransferExporter;
 
 use crate::{model::Model, Result};
-use chrono::{DateTime, FixedOffset, TimeZone};
+use time::OffsetDateTime;
 
 /// Configuration options for exporting a NeTEx France.
 /// 3 options can be configured:
@@ -47,7 +47,7 @@ use chrono::{DateTime, FixedOffset, TimeZone};
 pub struct WriteConfiguration {
     participant: String,
     stop_provider: Option<String>,
-    current_datetime: DateTime<FixedOffset>,
+    current_datetime: OffsetDateTime,
 }
 
 impl WriteConfiguration {
@@ -56,8 +56,7 @@ impl WriteConfiguration {
         WriteConfiguration {
             participant: participant.into(),
             stop_provider: None,
-            current_datetime: chrono::FixedOffset::east(0)
-                .from_utc_datetime(&chrono::Utc::now().naive_utc()),
+            current_datetime: OffsetDateTime::now_utc(),
         }
     }
     /// Setup the Stop Provider (see [specifications](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_to_netex_france_specs.md) for more details)
@@ -68,7 +67,7 @@ impl WriteConfiguration {
         }
     }
     /// Setup the date and time of the export.
-    pub fn current_datetime(self, current_datetime: DateTime<FixedOffset>) -> Self {
+    pub fn current_datetime(self, current_datetime: OffsetDateTime) -> Self {
         WriteConfiguration {
             current_datetime,
             ..self

--- a/src/netex_france/offer.rs
+++ b/src/netex_france/offer.rs
@@ -718,11 +718,12 @@ mod tests {
     use crate::{
         model::Collections,
         objects::{
-            Calendar, CommercialMode, Company, Contributor, Dataset, Date, Network, PhysicalMode,
+            Calendar, CommercialMode, Company, Contributor, Dataset, Network, PhysicalMode,
             StopArea, StopPoint, StopTimePrecision, Time,
         },
     };
     use pretty_assertions::assert_eq;
+    use time::{Date, Month};
     use typed_index_collection::CollectionWithId;
 
     fn default_collections() -> Collections {
@@ -789,7 +790,9 @@ mod tests {
         });
         collections.calendars = CollectionWithId::from(Calendar {
             id: String::from("service_id"),
-            dates: vec![Date::from_ymd(2020, 1, 1)].into_iter().collect(),
+            dates: vec![Date::from_calendar_date(2020, Month::January, 1).unwrap()]
+                .into_iter()
+                .collect(),
         });
         collections.vehicle_journeys = CollectionWithId::from(VehicleJourney {
             id: String::from("vj_id_1"),

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -17,7 +17,6 @@
 #![allow(missing_docs)]
 
 use crate::{serde_utils::*, AddPrefix, PrefixConfiguration};
-use chrono::NaiveDate;
 use chrono_tz::Tz;
 use derivative::Derivative;
 use geo::{Geometry as GeoGeometry, Point as GeoPoint};
@@ -29,6 +28,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Add, Div, Rem, Sub};
 use std::str::FromStr;
 use thiserror::Error;
+use time::{Date, Duration, OffsetDateTime};
 use typed_index_collection::{impl_id, impl_with_id, Idx, WithId};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
@@ -197,15 +197,14 @@ pub struct ValidityPeriod {
 
 impl Default for ValidityPeriod {
     fn default() -> ValidityPeriod {
-        use chrono::{Duration, Utc};
         let duration = Duration::days(15);
-        let today = Utc::today();
+        let today = OffsetDateTime::now_utc();
         let start_date = today - duration;
         let end_date = today + duration;
 
         ValidityPeriod {
-            start_date: start_date.naive_utc(),
-            end_date: end_date.naive_utc(),
+            start_date: start_date.date(),
+            end_date: end_date.date(),
         }
     }
 }
@@ -217,14 +216,14 @@ pub struct Dataset {
     pub contributor_id: String,
     #[serde(
         rename = "dataset_start_date",
-        deserialize_with = "de_from_date_string",
-        serialize_with = "ser_from_naive_date"
+        deserialize_with = "de_into_time_date",
+        serialize_with = "ser_from_time_date"
     )]
     pub start_date: Date,
     #[serde(
         rename = "dataset_end_date",
-        deserialize_with = "de_from_date_string",
-        serialize_with = "ser_from_naive_date"
+        deserialize_with = "de_into_time_date",
+        serialize_with = "ser_from_time_date"
     )]
     pub end_date: Date,
     pub dataset_type: Option<DatasetType>,
@@ -1291,8 +1290,6 @@ impl AddPrefix for Level {
 }
 impl_id!(Level);
 
-pub type Date = chrono::NaiveDate;
-
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum ExceptionType {
     #[serde(rename = "1")]
@@ -1607,15 +1604,15 @@ impl AddPrefix for AdminStation {
 pub struct PriceV1 {
     pub id: String,
     #[serde(
-        deserialize_with = "de_from_date_string",
-        serialize_with = "ser_from_naive_date"
+        deserialize_with = "de_into_time_date",
+        serialize_with = "ser_from_time_date"
     )]
-    pub start_date: NaiveDate,
+    pub start_date: Date,
     #[serde(
-        deserialize_with = "de_from_date_string",
-        serialize_with = "ser_from_naive_date"
+        deserialize_with = "de_into_time_date",
+        serialize_with = "ser_from_time_date"
     )]
-    pub end_date: NaiveDate,
+    pub end_date: Date,
     pub price: u32,
     pub name: String,
     pub ignored: String,
@@ -1713,13 +1710,13 @@ pub struct TicketPrice {
     )]
     pub currency: String,
     #[serde(
-        deserialize_with = "de_from_date_string",
-        serialize_with = "ser_from_naive_date"
+        deserialize_with = "de_into_time_date",
+        serialize_with = "ser_from_time_date"
     )]
     pub ticket_validity_start: Date,
     #[serde(
-        deserialize_with = "de_from_date_string",
-        serialize_with = "ser_from_naive_date"
+        deserialize_with = "de_into_time_date",
+        serialize_with = "ser_from_time_date"
     )]
     pub ticket_validity_end: Date,
 }
@@ -1827,8 +1824,8 @@ impl AddPrefix for GridCalendar {
 pub struct GridExceptionDate {
     pub grid_calendar_id: String,
     #[serde(
-        deserialize_with = "de_from_date_string",
-        serialize_with = "ser_from_naive_date"
+        deserialize_with = "de_into_time_date",
+        serialize_with = "ser_from_time_date"
     )]
     pub date: Date,
     #[serde(deserialize_with = "de_from_u8", serialize_with = "ser_from_bool")]
@@ -1846,13 +1843,13 @@ impl AddPrefix for GridExceptionDate {
 pub struct GridPeriod {
     pub grid_calendar_id: String,
     #[serde(
-        deserialize_with = "de_from_date_string",
-        serialize_with = "ser_from_naive_date"
+        deserialize_with = "de_into_time_date",
+        serialize_with = "ser_from_time_date"
     )]
     pub start_date: Date,
     #[serde(
-        deserialize_with = "de_from_date_string",
-        serialize_with = "ser_from_naive_date"
+        deserialize_with = "de_into_time_date",
+        serialize_with = "ser_from_time_date"
     )]
     pub end_date: Date,
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -12,7 +12,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>
 
-use chrono::{DateTime, FixedOffset};
 use pretty_assertions::assert_eq;
 use std::collections::BTreeSet;
 use std::fs;
@@ -21,6 +20,7 @@ use std::io::{prelude::*, BufReader};
 use std::path;
 use std::path::Path;
 use tempfile::tempdir;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 pub fn get_file_content<P: AsRef<Path>>(path: P) -> Vec<String> {
     let path = path.as_ref();
@@ -144,6 +144,6 @@ where
     tmp_dir.close().expect("delete temp dir");
 }
 
-pub fn get_test_datetime() -> DateTime<FixedOffset> {
-    DateTime::parse_from_rfc3339("2019-04-03T17:19:00Z").unwrap()
+pub fn get_test_datetime() -> OffsetDateTime {
+    OffsetDateTime::parse("2019-04-03T17:19:00Z", &Rfc3339).unwrap()
 }

--- a/src/validity_period.rs
+++ b/src/validity_period.rs
@@ -75,19 +75,19 @@ mod tests {
 
     mod set_validity_period {
         use super::super::*;
-        use crate::objects::{Dataset, Date, ValidityPeriod};
-        use chrono::naive::{MAX_DATE, MIN_DATE};
+        use crate::objects::{Dataset, ValidityPeriod};
         use pretty_assertions::assert_eq;
+        use time::{Date, Month};
 
         #[test]
         fn no_existing_validity_period() {
-            let start_date = Date::from_ymd(2019, 1, 1);
-            let end_date = Date::from_ymd(2019, 6, 30);
+            let start_date = Date::from_calendar_date(2019, Month::January, 1).unwrap();
+            let end_date = Date::from_calendar_date(2019, Month::June, 30).unwrap();
             let mut dataset = Dataset {
                 id: String::from("dataset_id"),
                 contributor_id: String::from("contributor_id"),
-                start_date: MAX_DATE,
-                end_date: MIN_DATE,
+                start_date: Date::MAX,
+                end_date: Date::MIN,
                 ..Default::default()
             };
             let service_validity_period = ValidityPeriod {
@@ -101,13 +101,13 @@ mod tests {
 
         #[test]
         fn with_extended_validity_period() {
-            let start_date = Date::from_ymd(2019, 1, 1);
-            let end_date = Date::from_ymd(2019, 6, 30);
+            let start_date = Date::from_calendar_date(2019, Month::January, 1).unwrap();
+            let end_date = Date::from_calendar_date(2019, Month::June, 30).unwrap();
             let mut dataset = Dataset {
                 id: String::from("dataset_id"),
                 contributor_id: String::from("contributor_id"),
-                start_date: Date::from_ymd(2019, 3, 1),
-                end_date: Date::from_ymd(2019, 4, 30),
+                start_date: Date::from_calendar_date(2019, Month::March, 1).unwrap(),
+                end_date: Date::from_calendar_date(2019, Month::April, 30).unwrap(),
                 ..Default::default()
             };
             let service_validity_period = ValidityPeriod {
@@ -121,8 +121,8 @@ mod tests {
 
         #[test]
         fn with_included_validity_period() {
-            let start_date = Date::from_ymd(2019, 1, 1);
-            let end_date = Date::from_ymd(2019, 6, 30);
+            let start_date = Date::from_calendar_date(2019, Month::January, 1).unwrap();
+            let end_date = Date::from_calendar_date(2019, Month::June, 30).unwrap();
             let mut dataset = Dataset {
                 id: String::from("dataset_id"),
                 contributor_id: String::from("contributor_id"),
@@ -131,8 +131,8 @@ mod tests {
                 ..Default::default()
             };
             let service_validity_period = ValidityPeriod {
-                start_date: Date::from_ymd(2019, 3, 1),
-                end_date: Date::from_ymd(2019, 4, 30),
+                start_date: Date::from_calendar_date(2019, Month::March, 1).unwrap(),
+                end_date: Date::from_calendar_date(2019, Month::April, 30).unwrap(),
             };
             set_dataset_validity_period(&mut dataset, &service_validity_period);
             assert_eq!(start_date, dataset.start_date);
@@ -146,6 +146,7 @@ mod tests {
             calendars, configuration::*, file_handler::PathFileHandler, model::Collections,
             test_utils::*,
         };
+        use time::{Date, Month};
 
         #[test]
         fn test_compute_dataset_validity_period() {
@@ -171,8 +172,8 @@ mod tests {
                     Dataset {
                         id: "default_dataset".to_string(),
                         contributor_id: "default_contributor".to_string(),
-                        start_date: chrono::NaiveDate::from_ymd(2018, 5, 1),
-                        end_date: chrono::NaiveDate::from_ymd(2018, 5, 19),
+                        start_date: Date::from_calendar_date(2018, Month::May, 1).unwrap(),
+                        end_date: Date::from_calendar_date(2018, Month::May, 19).unwrap(),
                         dataset_type: None,
                         extrapolation: false,
                         desc: None,
@@ -202,8 +203,8 @@ mod tests {
                     Dataset {
                         id: "default_dataset".to_string(),
                         contributor_id: "default_contributor".to_string(),
-                        start_date: chrono::NaiveDate::from_ymd(2018, 5, 1),
-                        end_date: chrono::NaiveDate::from_ymd(2018, 5, 1),
+                        start_date: Date::from_calendar_date(2018, Month::May, 1).unwrap(),
+                        end_date: Date::from_calendar_date(2018, Month::May, 1).unwrap(),
                         dataset_type: None,
                         extrapolation: false,
                         desc: None,

--- a/src/vptranslator.rs
+++ b/src/vptranslator.rs
@@ -14,9 +14,9 @@
 
 //! See function translate
 
-use crate::objects::{Date, ExceptionType, ValidityPeriod};
-use chrono::{Datelike, Duration, Weekday};
-use num_traits::cast::FromPrimitive;
+use time::{Date, Duration, Weekday};
+
+use crate::objects::{ExceptionType, ValidityPeriod};
 use std::collections::BTreeSet;
 use std::vec::Vec;
 
@@ -41,14 +41,14 @@ pub struct BlockPattern {
 }
 
 fn get_prev_monday(date: Date) -> Date {
-    date - Duration::days(i64::from(date.weekday().num_days_from_monday()))
+    date - Duration::days(i64::from(date.weekday().number_days_from_monday()))
 }
 
 fn compute_validity_pattern(start_date: Date, end_date: Date, dates: &BTreeSet<Date>) -> Vec<u8> {
-    let length = (end_date.signed_duration_since(start_date).num_weeks() + 1) as usize;
+    let length = ((end_date - start_date).whole_weeks() + 1) as usize;
     let mut res = vec![0; length];
     for date in dates {
-        let w = date.signed_duration_since(start_date).num_weeks() as usize;
+        let w = (*date - start_date).whole_weeks() as usize;
         res[w] |= 1 << (7 - date.weekday().number_from_monday());
     }
     res
@@ -99,10 +99,20 @@ fn get_operating_days(week: u8) -> Vec<Weekday> {
     let mut res = Vec::new();
     for i in 0..7 {
         if week & (1 << i) == (1 << i) {
-            res.push(Weekday::from_u8(6 - i).unwrap());
+            let weekday = match 6 - i {
+                0 => Weekday::Monday,
+                1 => Weekday::Tuesday,
+                2 => Weekday::Wednesday,
+                3 => Weekday::Thursday,
+                4 => Weekday::Friday,
+                5 => Weekday::Saturday,
+                6 => Weekday::Sunday,
+                _ => unreachable!(),
+            };
+            res.push(weekday);
         }
     }
-    res.sort_by_key(Weekday::num_days_from_monday);
+    res.sort_by_key(|weekday| weekday.number_days_from_monday());
     res
 }
 
@@ -168,6 +178,7 @@ pub fn translate(dates: &BTreeSet<Date>) -> BlockPattern {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+    use time::Month;
 
     fn compute_between(start_date: Date, end_date: Date) -> Vec<u8> {
         let mut dates = BTreeSet::new();
@@ -180,7 +191,11 @@ mod tests {
     fn one_week() {
         assert_eq!(
             1,
-            compute_between(Date::from_ymd(2012, 7, 2), Date::from_ymd(2012, 7, 8)).len()
+            compute_between(
+                Date::from_calendar_date(2012, Month::July, 2).unwrap(),
+                Date::from_calendar_date(2012, Month::July, 8).unwrap()
+            )
+            .len()
         );
     }
 
@@ -188,7 +203,11 @@ mod tests {
     fn partial_one_week() {
         assert_eq!(
             2,
-            compute_between(Date::from_ymd(2012, 7, 4), Date::from_ymd(2012, 7, 15)).len()
+            compute_between(
+                Date::from_calendar_date(2012, Month::July, 4).unwrap(),
+                Date::from_calendar_date(2012, Month::July, 15).unwrap()
+            )
+            .len()
         );
     }
 
@@ -196,7 +215,11 @@ mod tests {
     fn one_week_partial() {
         assert_eq!(
             2,
-            compute_between(Date::from_ymd(2012, 7, 2), Date::from_ymd(2012, 7, 13)).len()
+            compute_between(
+                Date::from_calendar_date(2012, Month::July, 2).unwrap(),
+                Date::from_calendar_date(2012, Month::July, 13).unwrap()
+            )
+            .len()
         );
     }
 
@@ -204,7 +227,11 @@ mod tests {
     fn partial_one_week_partial_with_nb_partial_6() {
         assert_eq!(
             3,
-            compute_between(Date::from_ymd(2012, 7, 4), Date::from_ymd(2012, 7, 17)).len()
+            compute_between(
+                Date::from_calendar_date(2012, Month::July, 4).unwrap(),
+                Date::from_calendar_date(2012, Month::July, 17).unwrap()
+            )
+            .len()
         );
     }
 
@@ -212,7 +239,11 @@ mod tests {
     fn partial_one_week_partial_with_nb_partial_7() {
         assert_eq!(
             3,
-            compute_between(Date::from_ymd(2012, 7, 4), Date::from_ymd(2012, 7, 18)).len()
+            compute_between(
+                Date::from_calendar_date(2012, Month::July, 4).unwrap(),
+                Date::from_calendar_date(2012, Month::July, 18).unwrap()
+            )
+            .len()
         );
     }
 
@@ -220,31 +251,35 @@ mod tests {
     fn partial_one_week_partial_with_nb_partial_8() {
         assert_eq!(
             3,
-            compute_between(Date::from_ymd(2012, 7, 4), Date::from_ymd(2012, 7, 19)).len()
+            compute_between(
+                Date::from_calendar_date(2012, Month::July, 4).unwrap(),
+                Date::from_calendar_date(2012, Month::July, 19).unwrap()
+            )
+            .len()
         );
     }
 
     #[test]
     fn prev_monday_from_monday() {
         assert_eq!(
-            Date::from_ymd(2012, 7, 2),
-            get_prev_monday(Date::from_ymd(2012, 7, 2))
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
+            get_prev_monday(Date::from_calendar_date(2012, Month::July, 2).unwrap())
         );
     }
 
     #[test]
     fn prev_monday_from_thursday() {
         assert_eq!(
-            Date::from_ymd(2012, 7, 2),
-            get_prev_monday(Date::from_ymd(2012, 7, 5))
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
+            get_prev_monday(Date::from_calendar_date(2012, Month::July, 5).unwrap())
         );
     }
 
     #[test]
     fn prev_monday_from_sunday() {
         assert_eq!(
-            Date::from_ymd(2012, 7, 2),
-            get_prev_monday(Date::from_ymd(2012, 7, 8))
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
+            get_prev_monday(Date::from_calendar_date(2012, Month::July, 8).unwrap())
         );
     }
 
@@ -270,15 +305,15 @@ mod tests {
     fn only_first_day() {
         let mut dates = BTreeSet::new();
 
-        dates.insert(Date::from_ymd(2012, 7, 2));
+        dates.insert(Date::from_calendar_date(2012, Month::July, 2).unwrap());
         let res = translate(&dates);
         assert_eq!(0b100_0000, get_week_from_weekday(res.operating_days));
 
         assert!(res.exceptions.is_empty());
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 2),
-                end_date: Date::from_ymd(2012, 7, 2),
+                start_date: Date::from_calendar_date(2012, Month::July, 2).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 2).unwrap(),
             },
             res.validity_period.unwrap()
         );
@@ -287,7 +322,7 @@ mod tests {
     #[test]
     fn bound_cut() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 16),
+            Date::from_calendar_date(2012, Month::July, 16).unwrap(),
             &format!("{}{}", "0011101", "000"),
         ));
 
@@ -295,8 +330,8 @@ mod tests {
         assert!(res.exceptions.is_empty());
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 18),
-                end_date: Date::from_ymd(2012, 7, 22),
+                start_date: Date::from_calendar_date(2012, Month::July, 18).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 22).unwrap(),
             },
             res.validity_period.unwrap()
         );
@@ -305,7 +340,7 @@ mod tests {
     #[test]
     fn bound_cut_one_day() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 16),
+            Date::from_calendar_date(2012, Month::July, 16).unwrap(),
             &format!("{}{}", "0000010", "00"),
         ));
 
@@ -313,8 +348,8 @@ mod tests {
         assert!(res.exceptions.is_empty());
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 21),
-                end_date: Date::from_ymd(2012, 7, 21),
+                start_date: Date::from_calendar_date(2012, Month::July, 21).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 21).unwrap(),
             },
             res.validity_period.unwrap()
         )
@@ -323,7 +358,7 @@ mod tests {
     #[test]
     fn empty_vp() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 16),
+            Date::from_calendar_date(2012, Month::July, 16).unwrap(),
             &"0000000".to_string(),
         ));
 
@@ -335,7 +370,7 @@ mod tests {
     #[test]
     fn only_one_thursday() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 2),
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
             &format!("{}{}", "0000000", "0001000"),
         ));
 
@@ -343,8 +378,8 @@ mod tests {
         assert!(res.exceptions.is_empty());
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 12),
-                end_date: Date::from_ymd(2012, 7, 12),
+                start_date: Date::from_calendar_date(2012, Month::July, 12).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 12).unwrap(),
             },
             res.validity_period.unwrap()
         )
@@ -353,7 +388,7 @@ mod tests {
     #[test]
     fn only_one_monday() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 2),
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
             &format!("{}{}", "0000000", "1000000"),
         ));
 
@@ -361,8 +396,8 @@ mod tests {
         assert!(res.exceptions.is_empty());
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 9),
-                end_date: Date::from_ymd(2012, 7, 9),
+                start_date: Date::from_calendar_date(2012, Month::July, 9).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 9).unwrap(),
             },
             res.validity_period.unwrap()
         )
@@ -371,7 +406,7 @@ mod tests {
     #[test]
     fn only_one_sunday() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 2),
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
             &format!("{}{}", "0000001", "0000000"),
         ));
 
@@ -379,8 +414,8 @@ mod tests {
         assert!(res.exceptions.is_empty());
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 8),
-                end_date: Date::from_ymd(2012, 7, 8),
+                start_date: Date::from_calendar_date(2012, Month::July, 8).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 8).unwrap(),
             },
             res.validity_period.unwrap()
         )
@@ -390,7 +425,7 @@ mod tests {
     #[test]
     fn only_one_tfss() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 2),
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
             &format!("{}{}", "0000000", "0001111"),
         ));
 
@@ -398,8 +433,8 @@ mod tests {
         assert!(res.exceptions.is_empty());
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 12),
-                end_date: Date::from_ymd(2012, 7, 15),
+                start_date: Date::from_calendar_date(2012, Month::July, 12).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 15).unwrap(),
             },
             res.validity_period.unwrap()
         )
@@ -408,7 +443,7 @@ mod tests {
     #[test]
     fn three_complete_weeks() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 2),
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
             &format!("{}{}{}", "1111111", "1111111", "1111111"),
         ));
 
@@ -416,8 +451,8 @@ mod tests {
         assert!(res.exceptions.is_empty());
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 2),
-                end_date: Date::from_ymd(2012, 7, 22),
+                start_date: Date::from_calendar_date(2012, Month::July, 2).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 22).unwrap(),
             },
             res.validity_period.unwrap()
         )
@@ -426,7 +461,7 @@ mod tests {
     #[test]
     fn three_mtwss_excluding_one_day() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 2),
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
             &format!("{}{}{}", "1100111", "1100011", "1100111"),
         ));
 
@@ -434,15 +469,15 @@ mod tests {
         assert_eq!(1, res.exceptions.len());
         assert_eq!(
             &ExceptionDate {
-                date: Date::from_ymd(2012, 7, 13),
+                date: Date::from_calendar_date(2012, Month::July, 13).unwrap(),
                 exception_type: ExceptionType::Remove,
             },
             res.exceptions.get(0).unwrap()
         );
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 2),
-                end_date: Date::from_ymd(2012, 7, 22),
+                start_date: Date::from_calendar_date(2012, Month::July, 2).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 22).unwrap(),
             },
             res.validity_period.unwrap()
         )
@@ -451,7 +486,7 @@ mod tests {
     #[test]
     fn three_mtwss_including_one_day() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 2),
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
             &format!("{}{}{}", "1100111", "1101111", "1100111"),
         ));
 
@@ -459,15 +494,15 @@ mod tests {
         assert_eq!(1, res.exceptions.len());
         assert_eq!(
             &ExceptionDate {
-                date: Date::from_ymd(2012, 7, 12),
+                date: Date::from_calendar_date(2012, Month::July, 12).unwrap(),
                 exception_type: ExceptionType::Add,
             },
             res.exceptions.get(0).unwrap()
         );
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 2),
-                end_date: Date::from_ymd(2012, 7, 22),
+                start_date: Date::from_calendar_date(2012, Month::July, 2).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 22).unwrap(),
             },
             res.validity_period.unwrap()
         )
@@ -476,7 +511,7 @@ mod tests {
     #[test]
     fn mwtfss_mttfss_mtwfss() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 2),
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
             &format!("{}{}{}", "1011111", "1101111", "1110111"),
         ));
 
@@ -485,29 +520,29 @@ mod tests {
 
         assert_eq!(
             ExceptionDate {
-                date: Date::from_ymd(2012, 7, 3),
+                date: Date::from_calendar_date(2012, Month::July, 3).unwrap(),
                 exception_type: ExceptionType::Remove,
             },
             res.exceptions[0]
         );
         assert_eq!(
             ExceptionDate {
-                date: Date::from_ymd(2012, 7, 11),
+                date: Date::from_calendar_date(2012, Month::July, 11).unwrap(),
                 exception_type: ExceptionType::Remove,
             },
             res.exceptions[1]
         );
         assert_eq!(
             ExceptionDate {
-                date: Date::from_ymd(2012, 7, 19),
+                date: Date::from_calendar_date(2012, Month::July, 19).unwrap(),
                 exception_type: ExceptionType::Remove,
             },
             res.exceptions[2]
         );
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 2),
-                end_date: Date::from_ymd(2012, 7, 22),
+                start_date: Date::from_calendar_date(2012, Month::July, 2).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 22).unwrap(),
             },
             res.validity_period.unwrap()
         )
@@ -516,7 +551,7 @@ mod tests {
     #[test]
     fn t_w_t() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 2),
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
             &format!("{}{}{}", "0100000", "0010000", "0001000"),
         ));
 
@@ -524,29 +559,29 @@ mod tests {
         assert_eq!(3, res.exceptions.len());
         assert_eq!(
             ExceptionDate {
-                date: Date::from_ymd(2012, 7, 3),
+                date: Date::from_calendar_date(2012, Month::July, 3).unwrap(),
                 exception_type: ExceptionType::Add,
             },
             res.exceptions[0]
         );
         assert_eq!(
             ExceptionDate {
-                date: Date::from_ymd(2012, 7, 11),
+                date: Date::from_calendar_date(2012, Month::July, 11).unwrap(),
                 exception_type: ExceptionType::Add,
             },
             res.exceptions[1]
         );
         assert_eq!(
             ExceptionDate {
-                date: Date::from_ymd(2012, 7, 19),
+                date: Date::from_calendar_date(2012, Month::July, 19).unwrap(),
                 exception_type: ExceptionType::Add,
             },
             res.exceptions[2]
         );
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 3),
-                end_date: Date::from_ymd(2012, 7, 19),
+                start_date: Date::from_calendar_date(2012, Month::July, 3).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 19).unwrap(),
             },
             res.validity_period.unwrap()
         )
@@ -555,7 +590,7 @@ mod tests {
     #[test]
     fn bound_compression() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2012, 7, 2),
+            Date::from_calendar_date(2012, Month::July, 2).unwrap(),
             &format!("{}{}{}", "0000111", "0001111", "0001110"),
         ));
 
@@ -563,8 +598,8 @@ mod tests {
         assert!(res.exceptions.is_empty());
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2012, 7, 6),
-                end_date: Date::from_ymd(2012, 7, 21),
+                start_date: Date::from_calendar_date(2012, Month::July, 6).unwrap(),
+                end_date: Date::from_calendar_date(2012, Month::July, 21).unwrap(),
             },
             res.validity_period.unwrap()
         )
@@ -574,7 +609,7 @@ mod tests {
     #[test]
     fn may2015() {
         let res = translate(&get_dates_from_bitset(
-            Date::from_ymd(2015, 4, 27),
+            Date::from_calendar_date(2015, Month::April, 27).unwrap(),
             &format!(
                 "{}{}{}{}{}",
                 "1111000", "1111000", "1110100", "1111100", "0111110"
@@ -585,43 +620,43 @@ mod tests {
         assert_eq!(5, res.exceptions.len());
         assert_eq!(
             ExceptionDate {
-                date: Date::from_ymd(2015, 5, 1),
+                date: Date::from_calendar_date(2015, Month::May, 1).unwrap(),
                 exception_type: ExceptionType::Remove,
             },
             res.exceptions[0]
         );
         assert_eq!(
             ExceptionDate {
-                date: Date::from_ymd(2015, 5, 8),
+                date: Date::from_calendar_date(2015, Month::May, 8).unwrap(),
                 exception_type: ExceptionType::Remove,
             },
             res.exceptions[1]
         );
         assert_eq!(
             ExceptionDate {
-                date: Date::from_ymd(2015, 5, 14),
+                date: Date::from_calendar_date(2015, Month::May, 14).unwrap(),
                 exception_type: ExceptionType::Remove,
             },
             res.exceptions[2]
         );
         assert_eq!(
             ExceptionDate {
-                date: Date::from_ymd(2015, 5, 30),
+                date: Date::from_calendar_date(2015, Month::May, 30).unwrap(),
                 exception_type: ExceptionType::Add,
             },
             res.exceptions[3]
         );
         assert_eq!(
             ExceptionDate {
-                date: Date::from_ymd(2015, 5, 25),
+                date: Date::from_calendar_date(2015, Month::May, 25).unwrap(),
                 exception_type: ExceptionType::Remove,
             },
             res.exceptions[4]
         );
         assert_eq!(
             ValidityPeriod {
-                start_date: Date::from_ymd(2015, 4, 27),
-                end_date: Date::from_ymd(2015, 5, 30),
+                start_date: Date::from_calendar_date(2015, Month::April, 27).unwrap(),
+                end_date: Date::from_calendar_date(2015, Month::May, 30).unwrap(),
             },
             res.validity_period.unwrap()
         )

--- a/tests/fixtures/gtfs2ntfs/full_output/feed_infos.txt
+++ b/tests/fixtures/gtfs2ntfs/full_output/feed_infos.txt
@@ -1,7 +1,7 @@
 feed_info_param,feed_info_value
 feed_creation_date,20190403
 feed_creation_time,17:19:00
-feed_creation_datetime,2019-04-03T17:19:00+00:00
+feed_creation_datetime,2019-04-03T17:19:00Z
 feed_end_date,20180106
 feed_license,DefaultDatasourceLicense
 feed_license_url,http://www.default-datasource-website.com

--- a/tests/fixtures/gtfs2ntfs/minimal/output/feed_infos.txt
+++ b/tests/fixtures/gtfs2ntfs/minimal/output/feed_infos.txt
@@ -1,7 +1,7 @@
 feed_info_param,feed_info_value
 feed_creation_date,20190403
 feed_creation_time,17:19:00
-feed_creation_datetime,2019-04-03T17:19:00+00:00
+feed_creation_datetime,2019-04-03T17:19:00Z
 feed_end_date,20180106
 feed_start_date,20180101
 ntfs_version,0.12.1

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output/feed_infos.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output/feed_infos.txt
@@ -1,7 +1,7 @@
 feed_info_param,feed_info_value
 feed_creation_date,20190403
 feed_creation_time,17:19:00
-feed_creation_datetime,2019-04-03T17:19:00+00:00
+feed_creation_datetime,2019-04-03T17:19:00Z
 feed_end_date,20180106
 feed_start_date,20180101
 ntfs_version,0.12.1

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/feed_infos.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/feed_infos.txt
@@ -1,7 +1,7 @@
 feed_info_param,feed_info_value
 feed_creation_date,20190403
 feed_creation_time,17:19:00
-feed_creation_datetime,2019-04-03T17:19:00+00:00
+feed_creation_datetime,2019-04-03T17:19:00Z
 feed_end_date,20180106
 feed_start_date,20180101
 ntfs_version,0.12.1

--- a/tests/fixtures/netex_france/output/arrets.xml
+++ b/tests/fixtures/netex_france/output/arrets.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery version="1.09:FR-NETEX_ARRET-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
-	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
+	<PublicationTimestamp>2019-04-03T17:19:00Z</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
 		<GeneralFrame id="FR:GeneralFrame:NETEX_ARRET:" version="any">

--- a/tests/fixtures/netex_france/output/calendriers.xml
+++ b/tests/fixtures/netex_france/output/calendriers.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery version="1.09:FR-NETEX_CALENDRIER-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
-	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
+	<PublicationTimestamp>2019-04-03T17:19:00Z</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
 		<GeneralFrame id="FR:GeneralFrame:NETEX_CALENDRIER:" version="any">
 			<ValidBetween>
-				<FromDate>2018-01-01T00:00:00+00:00</FromDate>
-				<ToDate>2018-12-31T23:59:59+00:00</ToDate>
+				<FromDate>2018-01-01T00:00:00Z</FromDate>
+				<ToDate>2018-12-31T23:59:59Z</ToDate>
 			</ValidBetween>
 			<members>
 				<DayType id="FR:DayType:Week:" version="any">
@@ -18,7 +18,7 @@
 					</DayTypeRef>
 				</DayTypeAssignment>
 				<UicOperatingPeriod id="FR:UicOperatingPeriod:Week:" version="any">
-					<FromDate>2018-01-01T00:00:00+00:00</FromDate>
+					<FromDate>2018-01-01T00:00:00Z</FromDate>
 					<ValidDayBits>11111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001111100111110011111001</ValidDayBits>
 				</UicOperatingPeriod>
 			</members>

--- a/tests/fixtures/netex_france/output/correspondances.xml
+++ b/tests/fixtures/netex_france/output/correspondances.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery version="1.09:FR-NETEX_RESEAU-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
-	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
+	<PublicationTimestamp>2019-04-03T17:19:00Z</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
 		<GeneralFrame id="FR:GeneralFrame:NETEX_RESEAU:" version="any">

--- a/tests/fixtures/netex_france/output/lignes.xml
+++ b/tests/fixtures/netex_france/output/lignes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery version="1.09:FR-NETEX_LIGNE-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
-	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
+	<PublicationTimestamp>2019-04-03T17:19:00Z</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
 		<CompositeFrame id="FR:CompositeFrame:NETEX_LIGNE:" version="any">

--- a/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_5cd0eea3662b0f30bd419b47ecb64840.xml
+++ b/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_5cd0eea3662b0f30bd419b47ecb64840.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery version="1.09:FR-NETEX_HORAIRE-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
-	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
+	<PublicationTimestamp>2019-04-03T17:19:00Z</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
 		<GeneralFrame id="FR:GeneralFrame:NETEX_HORAIRE:" version="any">

--- a/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_MagicBus_23cdf50ee73fcba0d38beca2d8cc8c0e.xml
+++ b/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_MagicBus_23cdf50ee73fcba0d38beca2d8cc8c0e.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery version="1.09:FR-NETEX_HORAIRE-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
-	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
+	<PublicationTimestamp>2019-04-03T17:19:00Z</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
 		<GeneralFrame id="FR:GeneralFrame:NETEX_HORAIRE:" version="any">

--- a/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_f31e1eef20f64733a18c538073e78396.xml
+++ b/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_f31e1eef20f64733a18c538073e78396.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery version="1.09:FR-NETEX_HORAIRE-2.1-1.0" xmlns="http://www.netex.org.uk/netex" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.netex.org.uk/netex">
-	<PublicationTimestamp>2019-04-03T17:19:00+00:00</PublicationTimestamp>
+	<PublicationTimestamp>2019-04-03T17:19:00Z</PublicationTimestamp>
 	<ParticipantRef>Participant</ParticipantRef>
 	<dataObjects>
 		<GeneralFrame id="FR:GeneralFrame:NETEX_HORAIRE:" version="any">

--- a/tests/fixtures/restrict-validity-period/output/feed_infos.txt
+++ b/tests/fixtures/restrict-validity-period/output/feed_infos.txt
@@ -1,7 +1,7 @@
 feed_info_param,feed_info_value
 feed_creation_date,20190403
 feed_creation_time,17:19:00
-feed_creation_datetime,2019-04-03T17:19:00+00:00
+feed_creation_datetime,2019-04-03T17:19:00Z
 feed_end_date,20180805
 feed_start_date,20180501
 ntfs_version,0.12.1

--- a/tests/read_ntfs.rs
+++ b/tests/read_ntfs.rs
@@ -15,6 +15,7 @@
 use pretty_assertions::assert_eq;
 use relational_types::IdxSet;
 use std::collections::HashMap;
+use time::{Date, Month};
 use transit_model::model::{Collections, GetCorresponding, Model};
 use transit_model::objects::*;
 use transit_model::test_utils::*;
@@ -336,13 +337,13 @@ fn sanitize_grid() {
     };
     let grid_exception_date = GridExceptionDate {
         grid_calendar_id: String::from("grid_calendar_id"),
-        date: Date::from_ymd(2019, 1, 1),
+        date: Date::from_calendar_date(2019, Month::January, 1).unwrap(),
         r#type: true,
     };
     let grid_period = GridPeriod {
         grid_calendar_id: String::from("grid_calendar_id"),
-        start_date: Date::from_ymd(2019, 1, 1),
-        end_date: Date::from_ymd(2019, 12, 31),
+        start_date: Date::from_calendar_date(2019, Month::January, 1).unwrap(),
+        end_date: Date::from_calendar_date(2019, Month::December, 31).unwrap(),
     };
     let grid_rel_calendar_line = GridRelCalendarLine {
         grid_calendar_id: String::from("grid_calendar_id"),

--- a/tests/restrict_validity_period.rs
+++ b/tests/restrict_validity_period.rs
@@ -12,8 +12,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>
 
-use chrono::NaiveDate;
 use std::path::Path;
+use time::{Date, Month};
 use transit_model::model::Model;
 use transit_model::test_utils::*;
 
@@ -26,8 +26,8 @@ fn test_restrict_global() {
         let mut collections = objects.into_collections();
         collections
             .restrict_period(
-                NaiveDate::from_ymd(2018, 5, 1),
-                NaiveDate::from_ymd(2018, 8, 5),
+                Date::from_calendar_date(2018, Month::May, 1).unwrap(),
+                Date::from_calendar_date(2018, Month::August, 5).unwrap(),
             )
             .unwrap();
         let new_model = Model::new(collections).unwrap();
@@ -49,8 +49,8 @@ fn test_restrict_no_panic() {
         let mut collections = objects.into_collections();
         collections
             .restrict_period(
-                NaiveDate::from_ymd(2018, 8, 2),
-                NaiveDate::from_ymd(2019, 7, 31),
+                Date::from_calendar_date(2018, Month::August, 2).unwrap(),
+                Date::from_calendar_date(2019, Month::July, 31).unwrap(),
             )
             .unwrap();
         let new_model = Model::new(collections).unwrap();


### PR DESCRIPTION
This PR should be the start for removing our problem with the CI failing on `cargo audit`. Content of the PR:
- replace every use of `chrono` with an equivalent in `time`'s crate
- bumping to `tracing-susbcriber:0.3.0` (`tracing-subscriber:0.2.0` was using `chrono` as dependency)
- proposing [an upstream modification](https://github.com/chronotope/chrono-tz/pull/93) to `chrono-tz` to make dependency on `chrono` an optional **feature**

Noticeable changes are:
- I removed `transit_model::objects::Date` (see below for details)
- `time` does format `OffsetDateTime` with a final `Z` instead of `+00:00` which explains some changes in the output fixtures

# Removing `transit_model::objects::Date`

I see 2 reasons for removing it.

## Failure of the pattern

The first reason is the failure of this pattern. Making this alias and exposing it was supposed to make easy the change from one implementation to another implementation (so for example, from `chrono::NaiveDate` to `time::Date`). In reality, it doesn't work because the API of both objects are not the same. I could indeed transform the following line

```rust
pub type Date = chrono::NaiveDate;
```

into 

```rust
pub struct Date {
    inner: time::Date,
}
```

Then implement a backward compatible API with what was provided by `chrono::NaiveDate`. That's a lot of work.

## Exposing external API

In the end, doing an alias does change the type but does **not** change the underlying API, we're still exposing the API of `chrono::NaiveDate` (for example, `chrono::NaiveDate::from_ymd()` takes 3 integers... but such an API doesn't exist on `time::Date`).

## Revealing some more problems with `time::Date`

In the end, `type Date = time::Date;` would not be enough because for example, `time::Date::from_calendar_date()` also requires `time::Month`. This would not be impossible, I could do something like this.

```rust
pub struct Date {
    inner: time::Date,
}
impl Date {
	pub const MONTH_JANUARY = time::Month::January;
	pub const MONTH_FEBRUARY = time::Month::February;
    // ...
}
```
and so we should be able to use it without a dependency on `time`.

```rust
use transit_model::objects::Date;

let date = Date::from_calendar_date(2022, Date::MONTH_JANUARY, 1);
```

but this pushes the backward compatibility balance a step further still, and I'm not sure that we want to go that far.

## Conclusion

For me, the logical conclusion is to drop `transit_model::objects::Date`, therefore breaking backward compatibility. If you disagree and think we should go for the backward compatibility solution, please shout out.