### PR TITLE
feat: change default values for CO2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Hove <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.50.0"
+version = "0.51.0"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/hove-io/transit_model"

--- a/src/enhancers/fill_co2.rs
+++ b/src/enhancers/fill_co2.rs
@@ -18,10 +18,10 @@ lazy_static::lazy_static! {
         modes_map.insert(model::COACH_PHYSICAL_MODE, 171f32);
         modes_map.insert(model::FERRY_PHYSICAL_MODE, 279f32);
         modes_map.insert(model::FUNICULAR_PHYSICAL_MODE, 3f32);
-        modes_map.insert(model::LOCAL_TRAIN_PHYSICAL_MODE, 30.7f32);
-        modes_map.insert(model::LONG_DISTANCE_TRAIN_PHYSICAL_MODE, 3.4f32);
+        modes_map.insert(model::LOCAL_TRAIN_PHYSICAL_MODE, 29.6f32);
+        modes_map.insert(model::LONG_DISTANCE_TRAIN_PHYSICAL_MODE, 2.36f32);
         modes_map.insert(model::METRO_PHYSICAL_MODE, 3f32);
-        modes_map.insert(model::RAPID_TRANSIT_PHYSICAL_MODE, 6.2f32);
+        modes_map.insert(model::RAPID_TRANSIT_PHYSICAL_MODE, 7.28f32);
         // Unknown value
         // modes_map.insert(model::RailShuttle, 0.0f32);
         // Unknown value
@@ -30,7 +30,7 @@ lazy_static::lazy_static! {
         // modes_map.insert(model::SuspendedCableCar, 0.0f32);
         modes_map.insert(model::TAXI_PHYSICAL_MODE, 184f32);
         modes_map.insert(model::TRAIN_PHYSICAL_MODE, 11.9f32);
-        modes_map.insert(model::TRAMWAY_PHYSICAL_MODE, 4f32);
+        modes_map.insert(model::TRAMWAY_PHYSICAL_MODE, 3.29f32);
         modes_map
     };
 }

--- a/tests/fixtures/gtfs2ntfs/physical_modes/output/physical_modes.txt
+++ b/tests/fixtures/gtfs2ntfs/physical_modes/output/physical_modes.txt
@@ -11,4 +11,4 @@ Metro,Metro,3.0
 SuspendedCableCar,SuspendedCableCar,
 Taxi,Taxi,184.0
 Train,Train,11.9
-Tramway,Tramway,4.0
+Tramway,Tramway,3.29


### PR DESCRIPTION
ADEME made some update about the default values of CO2 per physical mode. See https://monimpacttransport.fr/.

ref: DATENG-337.