### PR TITLE
[tech] Remove max_release_level tracing feature in lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ serde_json = "1"
 skip_error = { version = "3.1", features = ["tracing"] }
 tempfile = "3"
 thiserror = "1"
-tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
+tracing = { version = "0.1", features = ["log"] }
 typed_index_collection = "2"
 walkdir = "2"
 wkt = "0.10"


### PR DESCRIPTION
I was trying to add more logs to my release build in loki, so I set 

```
tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
```
in my Cargo.toml. 
But to my surprise, I didn't get any `debug` level logs :dizzy_face: !

Some digging led me to the [log doc](https://docs.rs/log/latest/log/#compile-time-filters), that clearly says : 

> Libraries should avoid using the max level features because they’re global and can’t be changed once they’re set. 

Indeed, rust try to compiles a single version of `tracing` [when possible](https://doc.rust-lang.org/cargo/reference/resolver.html). 
In order to do so, it [unifies](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification) all features of tracing requested by all dependencies.

So if `transit_model` request the `release_max_level_info` feature for tracing, all crates (e.g. loki, mimir/bragi) using `transit_model` are forced with this choice, and will never be able to have debug/trace logs in their release build.

So the trick is to not specify these features in library code, and let the binaries active the feature as they see fit.

I checked all binaries in transit_model and [tartare_tools](https://github.com/hove-io/tartare-tools), and they all contains the "release_max_level_info", so this PR should not affect them.