### PR TITLE
feat: bump to 'chrono-tz:0.7.0'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Hove <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.51.2"
+version = "0.52.0"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/hove-io/transit_model"
@@ -40,7 +40,7 @@ mutable-model = []
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-chrono-tz = { version = "0.6", features = ["serde"] }
+chrono-tz = { version = "0.7", features = ["serde"] }
 csv = "1"
 derivative = "2"
 geo = "0.19"


### PR DESCRIPTION
Driven by the error in https://github.com/hove-io/loki/pull/322.