### PR TITLE
feat: implement 'Default' on 'Occupancy'

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1915,7 +1915,7 @@ pub enum OccupancyStatus {
     NotBoardable,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct Occupancy {
     pub line_id: String,
     pub from_stop_area: String,


### PR DESCRIPTION
`Default` has been implemented on `OccupancyStatus` which makes it possible to implement it on `Occupancy`. Let's do it!