### PR TITLE
Add deduplication on occupancies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Hove <core@hove.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.55.0"
+version = "0.56.0"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/hove-io/transit_model"

--- a/src/model.rs
+++ b/src/model.rs
@@ -591,6 +591,7 @@ impl Collections {
         self.grid_exception_dates = dedup_collection(&mut self.grid_exception_dates);
         self.grid_periods = dedup_collection(&mut self.grid_periods);
         self.grid_rel_calendar_line = dedup_collection(&mut self.grid_rel_calendar_line);
+        self.occupancies = dedup_collection(&mut self.occupancies);
 
         Ok(())
     }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1900,7 +1900,7 @@ impl AddPrefix for Address {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum OccupancyStatus {
     Empty,
@@ -1915,7 +1915,7 @@ pub enum OccupancyStatus {
     NotBoardable,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub struct Occupancy {
     pub line_id: String,
     pub from_stop_area: String,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1992,21 +1992,21 @@ mod tests {
             green: 255,
             blue: 255,
         };
-        assert_eq!("FFFFFF", serde_json::to_value(&white).unwrap());
+        assert_eq!("FFFFFF", serde_json::to_value(white).unwrap());
 
         let black = Rgb {
             red: 0,
             green: 0,
             blue: 0,
         };
-        assert_eq!("000000", serde_json::to_value(&black).unwrap());
+        assert_eq!("000000", serde_json::to_value(black).unwrap());
 
         let blue = Rgb {
             red: 0,
             green: 125,
             blue: 255,
         };
-        assert_eq!("007DFF", serde_json::to_value(&blue).unwrap());
+        assert_eq!("007DFF", serde_json::to_value(blue).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Seen with @pbench. We will possibly let the variation duplicates pass on `OccupancyStatus`.
It should be rare.

No clearing of occupancies dates. We will see in the future if necessary.