### PR TITLE
chore: clean-up of the crate's included files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,13 @@ edition = "2018"
 readme = "README.md"
 exclude = [
 	".gitignore",
-	".mergify.yml",
+	".gitmodules",
 	"CONTRIBUTING.md",
+	"Dockerfile",
+	"Makefile",
 	"README.md",
 	"examples/",
-	"src/documentation/",
+	"documentation/",
 	"tests/",
 ]
 


### PR DESCRIPTION
Mergify is not used anymore. And since I was removing this, I noticed a few other files and folders could be excluded as well.