### PR TITLE
Add Debian11 image builds

### DIFF
--- a/.github/workflows/continuous-integration-deb11.yml
+++ b/.github/workflows/continuous-integration-deb11.yml
@@ -1,0 +1,119 @@
+name: Continuous Integration (Debian11)
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - '*'
+  pull_request:
+
+env:
+  SBX_ECR_REGISTRY: "769000229800.dkr.ecr.eu-west-1.amazonaws.com"
+  PRD_ECR_REGISTRY: "162230498103.dkr.ecr.eu-west-1.amazonaws.com"
+  REGION: eu-west-1
+  ECR_IMAGE: datahub-common-transit_model
+  DEBIAN_TAG_SUFFIX: deb11
+
+jobs:
+  aws_creds:
+    name: Get ECR Access
+    runs-on: [self-hosted, dataeng, sandbox]
+    outputs:
+      token: ${{ steps.ecr_token.outputs.token }}
+    steps:
+      - id: ecr_token
+        name: Get ECR Token
+        run: |
+          echo token=$(aws ecr get-login-password --region $REGION) >> $GITHUB_OUTPUT
+  rustfmt:
+    name: Rust fmt check
+    needs: aws_creds
+    runs-on: [self-hosted, dataeng, sandbox]
+    container: 
+      image: 162230498103.dkr.ecr.eu-west-1.amazonaws.com/mutable-rust-ci:latest-deb11
+      credentials:
+        username: AWS
+        password: ${{ needs.aws_creds.outputs.token }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Format
+        run: make format
+  clippy:
+    name: Clippy check
+    needs: aws_creds
+    runs-on: [self-hosted, dataeng, sandbox]
+    container:
+      image: 162230498103.dkr.ecr.eu-west-1.amazonaws.com/mutable-rust-ci:latest-proj8.1.1-deb11
+      credentials:
+        username: AWS
+        password: ${{ needs.aws_creds.outputs.token }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Lint
+        run: make lint
+  audit:
+    name: Security audit
+    needs: aws_creds
+    runs-on: [self-hosted, dataeng, sandbox]
+    container:
+      image: 162230498103.dkr.ecr.eu-west-1.amazonaws.com/mutable-rust-ci:latest-proj8.1.1-deb11
+      credentials:
+        username: AWS
+        password: ${{ needs.aws_creds.outputs.token }}
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Audit
+        run: |
+          cargo audit
+  tests:
+    name: Tests
+    needs: aws_creds
+    runs-on: [self-hosted, dataeng, sandbox]
+    container:
+      image: 162230498103.dkr.ecr.eu-west-1.amazonaws.com/mutable-rust-ci:latest-proj8.1.1-deb11
+      credentials:
+        username: AWS
+        password: ${{ needs.aws_creds.outputs.token }}
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive # for tests/NeTEx
+    - name: Install xmllint
+      run: apt update && apt install --yes libxml2-utils
+    - name: Run tests with and without features
+      run: make test
+  build-n-push:
+    needs: [rustfmt, clippy, audit, tests]
+    if: github.event_name == 'push'
+    runs-on: [self-hosted, dataeng, sandbox]
+    steps:
+      - name: CleanUp
+        run: |
+          sudo chown -R $USER .
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          clean: false
+      - name: Login to Amazon ECR sandbox
+        env:
+          AWS_REGION: eu-west-1
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Login to Amazon ECR shared
+        env:
+          AWS_REGION: eu-west-1
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registries: 162230498103
+      - name: Build and Push to SBX ECR
+        if:  success()
+        run: |
+          docker build -t ${SBX_ECR_REGISTRY}/${ECR_IMAGE}:latest-${DEBIAN_TAG_SUFFIX} . -f Dockerfile_deb11
+          docker push ${SBX_ECR_REGISTRY}/${ECR_IMAGE}:latest-${DEBIAN_TAG_SUFFIX}
+      - name: Push release to Prod ECR
+        if: success() && startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG=${GITHUB_REF_NAME}
+          docker tag ${SBX_ECR_REGISTRY}/${ECR_IMAGE}:latest-${DEBIAN_TAG_SUFFIX} ${PRD_ECR_REGISTRY}/${ECR_IMAGE}:${TAG}-${DEBIAN_TAG_SUFFIX}
+          docker push ${PRD_ECR_REGISTRY}/${ECR_IMAGE}:${TAG}-${DEBIAN_TAG_SUFFIX}

--- a/Dockerfile_deb11
+++ b/Dockerfile_deb11
@@ -1,0 +1,9 @@
+FROM 162230498103.dkr.ecr.eu-west-1.amazonaws.com/mutable-rust-ci:latest-proj8.1.1-deb11 as builder
+WORKDIR /usr/src/app
+COPY . ./
+RUN git describe --tags --always && git status
+RUN cargo build --workspace --release
+RUN mkdir /usr/src/bin && for file in ls ${CARGO_TARGET_DIR:-./target}/release/*; do if test -f $file -a -x $file; then cp $file /usr/src/bin; fi; done
+
+FROM 162230498103.dkr.ecr.eu-west-1.amazonaws.com/mutable-proj-ci:8.1.1-deb11
+COPY --from=builder /usr/src/bin/* /usr/local/bin/


### PR DESCRIPTION
Note on GithubActions: temporary duplication of Continuous-Integration.
For more security, it's better to segment (tests + builds) for various versions of Debian (9 and 11).