### PR TITLE
[tech] Bump Tm to 0.57.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Hove <core@hove.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.57.0"
+version = "0.57.1"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/hove-io/transit_model"


### PR DESCRIPTION
Bump TransitModel to build/push both 0.57.1 images (Debian 9 and 11)