### PR TITLE
[ci] cargo test also builds doc tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,9 @@ test: ## Launch all tests
 	# Run all the tests of `transit_model` in the entire repository.
 
 	# First activating all features (including `xmllint`)
-	cargo test --workspace --all-features --all-targets  # `--all-targets` but no doctests
-	cargo test --workspace --all-features --doc          # doctests only
+	cargo test --workspace --all-features
 	# Then without features
-	cargo test --workspace --all-targets                 # `--all-targets` but no doctests
-	cargo test --workspace --doc                         # doctests only
+	cargo test --workspace
 
 help: ## Print this help message
 	@grep -E '^[a-zA-Z_-]+:.*## .*$$' $(CURDIR)/$(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
by default `cargo test` build doc tests`

see https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection