### PR TITLE
[fix] [ntfs2gtfs] Only create shapes for trips

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Hove <core@hove.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.74.0"
+version = "0.74.1"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/hove-io/transit_model"

--- a/ntfs2gtfs/tests/fixtures/output/shapes.txt
+++ b/ntfs2gtfs/tests/fixtures/output/shapes.txt
@@ -1,6 +1,4 @@
 shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence
-linestring_for_line,20.2,10.1,0
-linestring_for_line,40.4,30.3,1
 linestring_for_trip,20.2,10.1,0
 linestring_for_trip,40.4,30.3,1
 linestring_for_trip,60.6,50.5,2

--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -836,7 +836,7 @@ pub fn write<P: AsRef<Path>>(model: Model, path: P, extend_route_type: bool) -> 
         &model.stop_time_headsigns,
     )?;
     write::write_booking_rules(path, &model.booking_rules)?;
-    write::write_shapes(path, &model.geometries)?;
+    write::write_shapes(path, &model.geometries, &model.vehicle_journeys)?;
     write_collection_with_id(path, "pathways.txt", &model.pathways)?;
     write_collection_with_id(path, "levels.txt", &model.levels)?;
 

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -608,12 +608,12 @@ enum StopTimeType<'a> {
 ///     StopTimeType::WithPickupDropOffWindow(vec![&with_window_st1, &with_window_st2]),
 ///     StopTimeType::NoPickupDropOffWindow(vec![&without_window_st3]),
 /// ]
-fn group_stop_times_by_type(stop_times: &[StopTime]) -> Vec<StopTimeType> {
+fn group_stop_times_by_type(stop_times: &[StopTime]) -> Vec<StopTimeType<'_>> {
     let mut result = Vec::new();
     let mut current_group: Vec<&StopTime> = Vec::new();
     let mut last_with_pickup_dropoff_window: Option<bool> = None;
 
-    fn make_group(with_pickup_dropoff_window: bool, group: Vec<&StopTime>) -> StopTimeType {
+    fn make_group(with_pickup_dropoff_window: bool, group: Vec<&StopTime>) -> StopTimeType<'_> {
         if with_pickup_dropoff_window {
             StopTimeType::WithPickupDropOffWindow(group)
         } else {

--- a/src/gtfs/write.rs
+++ b/src/gtfs/write.rs
@@ -639,9 +639,14 @@ fn ntfs_geometry_to_gtfs_shapes(g: &objects::Geometry) -> impl Iterator<Item = S
 pub fn write_shapes(
     path: &path::Path,
     geometries: &CollectionWithId<objects::Geometry>,
+    vehicle_journeys: &CollectionWithId<VehicleJourney>,
 ) -> Result<()> {
-    let shapes: Vec<_> = geometries
+    let mut used_geometries = HashSet::new();
+    let shapes: Vec<_> = vehicle_journeys
         .values()
+        .filter_map(|vj| vj.geometry_id.as_ref())
+        .filter(|&geometry_id| used_geometries.insert(geometry_id))
+        .filter_map(|geometry_id| geometries.get(geometry_id))
         .flat_map(ntfs_geometry_to_gtfs_shapes)
         .collect();
     if !shapes.is_empty() {


### PR DESCRIPTION
Revert https://github.com/hove-io/transit_model/pull/980 as it does not respect GTFS specification
To merge after August 4

Ref. DHUB-1500