### PR TITLE
chore: CI - Use rust-cache

### DIFF
--- a/.github/workflows/continuous-integration-deb11.yml
+++ b/.github/workflows/continuous-integration-deb11.yml
@@ -82,6 +82,8 @@ jobs:
         submodules: recursive # for tests/NeTEx
     - name: Install xmllint
       run: apt update && apt install --yes libxml2-utils
+    - name: Cache cargo build
+      uses: Swatinem/rust-cache@v2
     - name: Run tests with and without features
       run: make test
   build-n-push:

--- a/.github/workflows/continuous-integration-deb12.yml
+++ b/.github/workflows/continuous-integration-deb12.yml
@@ -82,6 +82,8 @@ jobs:
         submodules: recursive # for tests/NeTEx
     - name: Install xmllint
       run: apt update && apt install --yes libxml2-utils
+    - name: Cache cargo build
+      uses: Swatinem/rust-cache@v2
     - name: Run tests with and without features
       run: make test
   build-n-push:


### PR DESCRIPTION
Uncertain about sharing between Debian 11 and Debian 12 (given the different distributions, there might be a conflict).